### PR TITLE
support and explain use of service_name options via cli or yaml.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -177,6 +177,29 @@ Finally, if you're using non-default configuration file, specify it to coveralls
 .. _report with only your packages: http://nedbatchelder.com/code/coverage/source.html#source
 .. _specify whole lines to .coveragerc: http://nedbatchelder.com/code/coverage/excluding.html
 
+Specifying the service_name
+---------------------------
+
+In order to specify a ``service_name`` value other than the default defined per-service, create a 
+``.coveralls.yml`` file in your project's root, naming the correct ``service_name``. For example, for
+``travis-pro``::
+
+    service_name: travis-pro
+
+For ``.coveralls.yml`` to load properly, alter your ``pip install`` configuration to read::
+
+    install:
+      - pip install -r requirements.txt
+      - pip install coveralls[yaml]
+
+If you prefer not to add a ``.coveralls.yml`` file, you may also use the ``--service=<name>`` command
+line option. To use this approach on our ``travis-pro`` example above, set your ``after_success`` 
+command to this::
+
+    after_success:
+      coveralls --service=travis-pro
+      
+No validation is done on this option, so make sure you are careful to use the correct value.
 
 Nosetests
 ~~~~~~~~~

--- a/coveralls/api.py
+++ b/coveralls/api.py
@@ -45,20 +45,26 @@ class Coveralls(object):
         repo_token = self.config.get('repo_token') or file_config.get('repo_token', None)
         if repo_token:
             self.config['repo_token'] = repo_token
+        service_name = self.config.get('service_name') or file_config.get('service_name', None)
+        if service_name:
+            self.config['service_name'] = service_name
 
         if os.environ.get('TRAVIS'):
             is_travis_or_circle = True
-            self.config['service_name'] = file_config.get('service_name', None) or 'travis-ci'
+            if self.config['service_name'] == self.default_client:
+                self.config['service_name'] = 'travis-ci'
             self.config['service_job_id'] = os.environ.get('TRAVIS_JOB_ID')
         elif os.environ.get('CIRCLECI'):
             is_travis_or_circle = True
-            self.config['service_name'] = file_config.get('service_name', None) or 'circle-ci'
+            if self.config['service_name'] == self.default_client:
+                self.config['service_name'] = 'circle-ci'
             self.config['service_job_id'] = os.environ.get('CIRCLE_BUILD_NUM')
             if os.environ.get('CI_PULL_REQUEST', None):
                 self.config['service_pull_request'] = os.environ.get('CI_PULL_REQUEST').split('/')[-1]
         elif os.environ.get('APPVEYOR'):
             is_travis_or_circle = False
-            self.config['service_name'] = file_config.get('service_name', None) or 'appveyor'
+            if self.config['service_name'] == self.default_client:
+                self.config['service_name'] = 'appveyor'
             self.config['service_job_id'] = os.environ.get('APPVEYOR_BUILD_ID')
             if os.environ.get('APPVEYOR_PULL_REQUEST_NUMBER'):
                 self.config['service_pull_request'] = os.environ['APPVEYOR_PULL_REQUEST_NUMBER']
@@ -78,6 +84,7 @@ class Coveralls(object):
             import yaml
             return yaml.safe_load(open(os.path.join(os.getcwd(), self.config_filename)))
         except ImportError:
+            log.debug('%s was not loaded; "import yaml" failed.', self.config_filename)
             return {}
         except (OSError, IOError):
             log.debug('Missing %s file. Using only env variables.', self.config_filename)

--- a/coveralls/cli.py
+++ b/coveralls/cli.py
@@ -17,6 +17,7 @@ Global options:
     --rcfile=<file>   Specify configuration file. [default: .coveragerc]
     --output=<file>   Write report to file.  Doesn't send anything.
     --merge=<file>    Merge report from file when submitting.
+    --service=<name>  Explicitly specify the service_name. [default: coveralls-python]
     -h --help         Display this help
     -v --verbose      Print extra info, True for debug command
 
@@ -47,7 +48,9 @@ def main(argv=None):
 
     try:
         token_required = not options['debug'] and not options['--output']
-        coverallz = Coveralls(token_required, config_file=options['--rcfile'])
+        coverallz = Coveralls(token_required,
+                              config_file=options['--rcfile'],
+                              service_name=options['--service'])
         if options['--merge']:
             coverallz.merge(options['--merge'])
 


### PR DESCRIPTION
This PR for #99 adds support for the following:
- suggestions for ways to specify `service_name` in the README.
- example of how to configure `pip install` to trigger installation of pyyaml.
- support for `--service=<name>` on the `coveralls` cli, eliminating the requirement for pyyaml in order to explicitly name the service.

This is a backwards-compatible change, as evidenced by the two screenshots below.

Note: I have also suggested to the Travis team that they add support for a `TRAVIS_PRO=true` environment variable. Time will tell on that one. Meanwhile, this PR offers two ways to get around the apparently-common problem of Coveralls getting mixed signals between `travis-ci` and `travis-pro` values on successful builds.

As `coveralls` behaved prior to this PR (with the new debug log message added):

![coveralls-default](https://cloud.githubusercontent.com/assets/33251/11607356/2c8e9314-9af8-11e5-8a36-216712e75ebc.png)

How `coveralls` behaves with the `--service=<name>` option.
![coveralls-with-service](https://cloud.githubusercontent.com/assets/33251/11607358/339e33f8-9af8-11e5-8ddd-f134f075b48c.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/coagulant/coveralls-python/101)
<!-- Reviewable:end -->
