### PR TITLE
Report partially covered branches as not covered

### DIFF
--- a/coveralls/reporter.py
+++ b/coveralls/reporter.py
@@ -56,9 +56,13 @@ class CoverallReporter(Reporter):
         """
         if line_num in analysis.missing:
             return 0
-        if line_num in analysis.statements:
+        if line_num not in analysis.statements:
+            return None
+        if not analysis.has_arcs():
             return 1
-        return None
+        if line_num in analysis.missing_branch_arcs():
+            return 0
+        return 1
 
     def parse_file(self, cu, analysis):
         """ Generate data for single file """

--- a/example/project.py
+++ b/example/project.py
@@ -11,3 +11,9 @@ class Foo(object):
 
 def baz():
     print('this is not tested')
+
+def branch(cond1, cond2):
+    if cond1:
+        print('condition tested both ways')
+    if cond2:
+        print('condition not tested both ways')

--- a/example/runtests.py
+++ b/example/runtests.py
@@ -1,5 +1,7 @@
 # coding: utf-8
-from project import hello
+from project import hello, branch
 
 if __name__ == '__main__':
     hello()
+    branch(False, True)
+    branch(True, True)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -183,12 +183,24 @@ class ReporterTest(unittest.TestCase):
         results = self.cover.get_coverage()
         assert len(results) == 2
         assert_coverage({
-            'source': '# coding: utf-8\n\n\ndef hello():\n    print(\'world\')\n\n\nclass Foo(object):\n    """ Bar """\n\n\ndef baz():\n    print(\'this is not tested\')',
+            'source': '# coding: utf-8\n\n\ndef hello():\n    print(\'world\')\n\n\nclass Foo(object):\n    """ Bar """\n\n\ndef baz():\n    print(\'this is not tested\')\n\ndef branch(cond1, cond2):\n    if cond1:\n        print(\'condition tested both ways\')\n    if cond2:\n        print(\'condition not tested both ways\')',
             'name': 'project.py',
-            'coverage': [None, None, None, 1, 1, None, None, 1, None, None, None, 1, 0]}, results[0])
+            'coverage': [None, None, None, 1, 1, None, None, 1, None, None, None, 1, 0, None, 1, 1, 1, 1, 1]}, results[0])
         assert_coverage({
-            'source': "# coding: utf-8\nfrom project import hello\n\nif __name__ == '__main__':\n    hello()",
-            'name': 'runtests.py', 'coverage': [None, 1, None, 1, 1]}, results[1])
+            'source': "# coding: utf-8\nfrom project import hello, branch\n\nif __name__ == '__main__':\n    hello()\n    branch(False, True)\n    branch(True, True)",
+            'name': 'runtests.py', 'coverage': [None, 1, None, 1, 1, 1, 1]}, results[1])
+
+    def test_reporter_with_branches(self):
+        sh.coverage('run', '--branch', 'runtests.py')
+        results = self.cover.get_coverage()
+        assert len(results) == 2
+        assert_coverage({
+            'source': '# coding: utf-8\n\n\ndef hello():\n    print(\'world\')\n\n\nclass Foo(object):\n    """ Bar """\n\n\ndef baz():\n    print(\'this is not tested\')\n\ndef branch(cond1, cond2):\n    if cond1:\n        print(\'condition tested both ways\')\n    if cond2:\n        print(\'condition not tested both ways\')',
+            'name': 'project.py',
+            'coverage': [None, None, None, 1, 1, None, None, 1, None, None, None, 1, 0, None, 1, 1, 1, 0, 1]}, results[0])
+        assert_coverage({
+            'source': "# coding: utf-8\nfrom project import hello, branch\n\nif __name__ == '__main__':\n    hello()\n    branch(False, True)\n    branch(True, True)",
+            'name': 'runtests.py', 'coverage': [None, 1, None, 0, 1, 1, 1]}, results[1])
 
     def test_missing_file(self):
         sh.echo('print("Python rocks!")', _out="extra.py")


### PR DESCRIPTION
Since coverage.io does not currently support branch coverage separately, I would like to mark those lines with only partial branch coverage as not covered.

If branch coverage is collected, this marks partially covered lines as not covered. If this implicit approach is not preferred, I could add an option for enabling this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/coagulant/coveralls-python/121)
<!-- Reviewable:end -->
