### PR TITLE
chore(dependencies): unpin pytest version, use pytest-runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.egg-info
 dist
 build
+.eggs
 eggs
 parts
 var

--- a/README.rst
+++ b/README.rst
@@ -84,7 +84,7 @@ Example of tox.ini::
 
     [testenv]
     passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
-    deps = 
+    deps =
         coveralls
     commands =
         coverage run --source=yourpackagename setup.py test
@@ -152,7 +152,7 @@ To exclude parts of your source from coverage, for example migrations folders::
     [report]
     omit = */migrations/*
 
-Some lines are never executed in your tests, but that can be ok. 
+Some lines are never executed in your tests, but that can be ok.
 To mark those lines use inline comments right in your source code::
 
     if debug:   # pragma: no cover
@@ -219,3 +219,8 @@ Run tests::
 
     $ python setup.py test
 
+Or, even better, use `tox`_::
+
+    $ tox
+
+.. _`tox`: http://tox.readthedocs.io/en/latest/index.html

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
+[aliases]
+test=pytest
+
 [wheel]
 universal = 1

--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,7 @@
-import sys
-from setuptools.command.test import test as TestCommand
 from setuptools import setup
 
 
-class PyTest(TestCommand):
-    def finalize_options(self):
-        TestCommand.finalize_options(self)
-        self.test_args = []
-        self.test_suite = True
-
-    def run_tests(self):
-        import pytest
-        errno = pytest.main(self.test_args)
-        sys.exit(errno)
+DESCRIPTION = open('README.rst').read() + '\n\n' + open('CHANGELOG.rst').read()
 
 
 setup(
@@ -24,18 +13,18 @@ setup(
     author='Ilya Baryshev',
     author_email='baryshev@gmail.com',
     description='Show coverage stats online via coveralls.io',
-    long_description=open('README.rst').read() + '\n\n' + open('CHANGELOG.rst').read(),
+    long_description=DESCRIPTION,
     entry_points={
         'console_scripts': [
             'coveralls = coveralls.cli:main',
         ],
     },
     install_requires=['docopt>=0.6.1', 'coverage>=3.6', 'requests>=1.0.0'],
-    tests_require=['mock', 'pytest>=2.7.3,<2.8', 'sh>=1.08'],
+    setup_requires=['pytest-runner'],
+    tests_require=['mock', 'pytest', 'sh>=1.08'],
     extras_require={
         'yaml': ['PyYAML>=3.10']
     },
-    cmdclass={'test': PyTest},
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Topic :: Software Development :: Testing',

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,9 +1,7 @@
 # coding: utf-8
 import os
-import sys
 
 from mock import patch, call
-import pytest
 
 import coveralls
 from coveralls.api import CoverallsException
@@ -33,7 +31,8 @@ def test_debug_no_token(mock_wear, mock_log):
 def test_real(mock_wear, mock_log):
     coveralls.cli.main(argv=[])
     mock_wear.assert_called_with()
-    mock_log.assert_has_calls([call("Submitting coverage to coveralls.io..."), call("Coverage submitted!")])
+    mock_log.assert_has_calls([call("Submitting coverage to coveralls.io..."),
+                               call("Coverage submitted!")])
 
 
 @patch.dict(os.environ, {'TRAVIS': 'True'}, clear=True)

--- a/tox.ini
+++ b/tox.ini
@@ -5,8 +5,9 @@ envlist = py{27,33,34,35,py,py3,py-54,py33-52-alpha1}-cov{3,4,41}-{default,pyyam
 passenv = *
 usedevelop = true
 deps =
-    pytest>=2.7.3,<2.8
     mock
+    pytest
+    pytest-runner
     sh
     pyyaml: PyYAML>=3.10
     cov3: coverage<4.0


### PR DESCRIPTION
Fixes #139 

Forced an install of the latest pytest (3.0.6) and found no errors. We should wait until CI works again before merging this, just to be sure.