### PR TITLE
Use coveralls' new branch reporting format

### DIFF
--- a/coveralls/reporter.py
+++ b/coveralls/reporter.py
@@ -63,14 +63,14 @@ class CoverallReporter(Reporter):
     def get_arcs(self, analysis):
         """ Hit stats for each branch.
 
-            Compacted array of:
-            * line-number
-            * block-number (not used)
-            * branch-number
-            * hits
+            Returns a flat list where every four values represent a branch:
+            1. line-number
+            2. block-number (not used)
+            3. branch-number
+            4. hits (we only get 1/0 from coverage.py)
         """
         if not analysis.has_arcs():
-            return []
+            return None
         branch_lines = analysis.branch_lines()
         executed = analysis.arcs_executed()
         missing = analysis.arcs_missing()
@@ -107,10 +107,14 @@ class CoverallReporter(Reporter):
             source_lines = list(enumerate(analysis.file_reporter.source_token_lines()))
             source = analysis.file_reporter.source()
         coverage_lines = [self.get_hits(i, analysis) for i in range(1, len(source_lines) + 1)]
-        branches = self.get_arcs(analysis)
-        self.source_files.append({
+
+        results = {
             'name': filename,
             'source': source,
             'coverage': coverage_lines,
-            'branches': branches,
-        })
+        }
+        branches = self.get_arcs(analysis)
+        if branches:
+            results['branches'] = branches
+
+        self.source_files.append(results)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -168,8 +168,7 @@ def assert_coverage(actual, expected):
     assert actual['source'].strip() == expected['source'].strip()
     assert actual['name'] == expected['name']
     assert actual['coverage'] == expected['coverage']
-    if 'branches' in actual and 'branches' in expected:
-        assert actual['branches'] == expected['branches']
+    assert actual.get('branches') == expected.get('branches')
 
 
 class ReporterTest(unittest.TestCase):
@@ -197,13 +196,9 @@ class ReporterTest(unittest.TestCase):
         results = self.cover.get_coverage()
         assert len(results) == 2
 
-        branches = results[0]['branches']
-        assert not len(branches) % 4
-        branches = [branches[i:i+4] for i in range(0, len(branches), 4)]
-        assert [16, 0, 17, 1] in branches
-        assert [16, 0, 18, 1] in branches
-        assert [18, 0, 19, 1] in branches
-        assert [18, 0, 15, 0] in branches
+        # Branches are expressed as four values each in a flat list
+        assert not len(results[0]['branches']) % 4
+        assert not len(results[1]['branches']) % 4
 
         assert_coverage({
             'source': '# coding: utf-8\n\n\ndef hello():\n    print(\'world\')\n\n\nclass Foo(object):\n    """ Bar """\n\n\ndef baz():\n    print(\'this is not tested\')\n\ndef branch(cond1, cond2):\n    if cond1:\n        print(\'condition tested both ways\')\n    if cond2:\n        print(\'condition not tested both ways\')',

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -168,6 +168,8 @@ def assert_coverage(actual, expected):
     assert actual['source'].strip() == expected['source'].strip()
     assert actual['name'] == expected['name']
     assert actual['coverage'] == expected['coverage']
+    if 'branches' in actual and 'branches' in expected:
+        assert actual['branches'] == expected['branches']
 
 
 class ReporterTest(unittest.TestCase):
@@ -194,13 +196,25 @@ class ReporterTest(unittest.TestCase):
         sh.coverage('run', '--branch', 'runtests.py')
         results = self.cover.get_coverage()
         assert len(results) == 2
+
+        branches = results[0]['branches']
+        assert not len(branches) % 4
+        branches = [branches[i:i+4] for i in range(0, len(branches), 4)]
+        assert [16, 0, 17, 1] in branches
+        assert [16, 0, 18, 1] in branches
+        assert [18, 0, 19, 1] in branches
+        assert [18, 0, 15, 0] in branches
+
         assert_coverage({
             'source': '# coding: utf-8\n\n\ndef hello():\n    print(\'world\')\n\n\nclass Foo(object):\n    """ Bar """\n\n\ndef baz():\n    print(\'this is not tested\')\n\ndef branch(cond1, cond2):\n    if cond1:\n        print(\'condition tested both ways\')\n    if cond2:\n        print(\'condition not tested both ways\')',
             'name': 'project.py',
-            'coverage': [None, None, None, 1, 1, None, None, 1, None, None, None, 1, 0, None, 1, 1, 1, 0, 1]}, results[0])
+            'branches': [16, 0, 17, 1, 16, 0, 18, 1, 18, 0, 19, 1, 18, 0, 15, 0],
+            'coverage': [None, None, None, 1, 1, None, None, 1, None, None, None, 1, 0, None, 1, 1, 1, 1, 1]}, results[0])
         assert_coverage({
             'source': "# coding: utf-8\nfrom project import hello, branch\n\nif __name__ == '__main__':\n    hello()\n    branch(False, True)\n    branch(True, True)",
-            'name': 'runtests.py', 'coverage': [None, 1, None, 0, 1, 1, 1]}, results[1])
+            'name': 'runtests.py',
+            'branches': [4, 0, 5, 1, 4, 0, 2, 0],
+            'coverage': [None, 1, None, 1, 1, 1, 1]}, results[1])
 
     def test_missing_file(self):
         sh.echo('print("Python rocks!")', _out="extra.py")

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ deps =
     cov4: coverage>=4.0,<4.1
     cov41: coverage>=4.1
 commands =
-    coverage run --source=coveralls setup.py test
+    coverage run --branch --source=coveralls setup.py test
     coverage report -m
 
 [testenv:coveralls3]


### PR DESCRIPTION
Fixes #143 

This changes branch coverage reporting to use the new branches field of the coveralls API.