### PR TITLE
Python 3.6 support and testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - 3.3
   - 3.4
   - 3.5
+  - 3.6
   - pypy-5.4
   - pypy3.3-5.2-alpha1
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,16 @@ python:
   - 3.3
   - 3.4
   - 3.5
-  - 3.6
   - pypy-5.4
   - pypy3.3-5.2-alpha1
 env:
-  matrix:
-    - $COVPYYAML=cov3-default,coveralls3
-    - $COVPYYAML=cov4-pyyaml,coveralls4
-    - $COVPYYAML=cov41-pyyaml,coveralls41
+  - $COVPYYAML=cov3-default,coveralls3
+  - $COVPYYAML=cov4-pyyaml,coveralls4
+  - $COVPYYAML=cov41-pyyaml,coveralls41
+matrix:
+  include:
+    - python: 3.6
+      env: $COVPYYAML=cov41-pyyaml,coveralls41
 install:
   - pip install tox
 script:

--- a/coveralls/reporter.py
+++ b/coveralls/reporter.py
@@ -3,6 +3,7 @@ import logging
 from os.path import basename
 import sys
 
+from coverage import __version__
 from coverage.misc import NoSource, NotPython
 from coverage.phystokens import source_encoding
 from coverage.report import Reporter
@@ -42,6 +43,14 @@ class CoverallReporter(Reporter):
                 # explicitly suppress those errors.
                 if cu.should_be_python() and not self.config.ignore_errors:
                     log.warn('Source file is not python %s', cu.filename)
+            except KeyError:
+                if __version__[0] < 4 or (__version__[0] == 4 and __version__[1] < 1):
+                    raise CoverallsException(
+                        'Old (<4.1) versions of coverage.py do not work consistently '
+                        'on new versions of Python. Please upgrade your coverage.py.'
+                    )
+                raise
+
 
         return self.source_files
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,33,34,35,py,py3,py-54,py33-52-alpha1}-cov{3,4,41}-{default,pyyaml}
+envlist = py{27,33,34,35,36,py,py3,py-54,py33-52-alpha1}-cov{3,4,41}-{default,pyyaml}
 
 [testenv]
 passenv = *

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,33,34,35,36,py,py3,py-54,py33-52-alpha1}-cov{3,4,41}-{default,pyyaml}
+envlist = py{27,33,34,35,py,py3,py-54,py33-52-alpha1}-cov{3,4,41}-{default,pyyaml},py36-cov41-{default,pyyaml}
 
 [testenv]
 passenv = *


### PR DESCRIPTION
This is based on cclauss' pull request #146 but with changes on top to:

1. Cope with broken versions of coverage.py on Python 3.6. Branch coverage is merely disabled, the rest should work.
2. Skip the tests which fail under these old versions, because it is not a bug in coveralls-python.