### PR TITLE
feat(jenkins): add logic to parse CI_PULL_REQUEST env variable

### DIFF
--- a/coveralls/api.py
+++ b/coveralls/api.py
@@ -81,7 +81,8 @@ class Coveralls(object):
 
     @staticmethod
     def load_config_from_jenkins():
-        return 'jenkins', os.environ.get('BUILD_NUMBER'), None
+        pr = os.environ.get('CI_PULL_REQUEST', '').split('/')[-1] or None
+        return 'jenkins', os.environ.get('BUILD_NUMBER'), pr
 
     @staticmethod
     def load_config_from_travis():

--- a/docs/usage/tox.rst
+++ b/docs/usage/tox.rst
@@ -40,7 +40,7 @@ Jenkins
 -------
 ::
 
-    passenv = JENKINS_HOME BUILD_NUMBER GIT_BRANCH
+    passenv = JENKINS_HOME BUILD_NUMBER GIT_BRANCH CI_PULL_REQUEST
 
 TravisCI
 --------

--- a/tests/api/configuration_test.py
+++ b/tests/api/configuration_test.py
@@ -91,12 +91,16 @@ class NoConfiguration(unittest.TestCase):
         assert cover.config['service_job_id'] == '888'
         assert cover.config['service_pull_request'] == '9999'
 
-    @mock.patch.dict(os.environ, {'JENKINS_HOME': '/var/lib/jenkins',
-                                  'BUILD_NUMBER': '888'}, clear=True)
+    @mock.patch.dict(os.environ,
+                     {'JENKINS_HOME': '/var/lib/jenkins',
+                      'BUILD_NUMBER': '888',
+                      'CI_PULL_REQUEST': 'https://github.com/org/repo/pull/9999'},
+                     clear=True)
     def test_jenkins_no_config(self):
         cover = Coveralls(repo_token='xxx')
         assert cover.config['service_name'] == 'jenkins'
         assert cover.config['service_job_id'] == '888'
+        assert cover.config['service_pull_request'] == '9999'
 
     @mock.patch.dict(os.environ, {'TRAVIS': 'True',
                                   'TRAVIS_JOB_ID': '777'}, clear=True)


### PR DESCRIPTION
add logic to parse `CI_PULL_REQUEST` env variable. 

Currently this variable is not parsed for jenkins configuration.  
https://coveralls.zendesk.com/hc/en-us/articles/201347419-Coveralls-currently-supports `JENKINS PULL REQUEST SUPPORT` section suggest to use it in conjunction with github pull request builder config 