### PR TITLE
Silently omit git argument when git is unavailable

### DIFF
--- a/coveralls/api.py
+++ b/coveralls/api.py
@@ -272,6 +272,13 @@ class Coveralls(object):
                 }]
             }
         """
+        # silently omit the optional 'git' API argument if a simple git status
+        # command fails, suggesting git is unavailable
+        try:
+            run_command('git', 'status')
+        except CoverallsException:
+            return {}
+
         rev = run_command('git', 'rev-parse', '--abbrev-ref', 'HEAD').strip()
         remotes = run_command('git', 'remote', '-v').splitlines()
 

--- a/coveralls/api.py
+++ b/coveralls/api.py
@@ -272,17 +272,16 @@ class Coveralls(object):
                 }]
             }
         """
-        # omit the optional 'git' API argument if a simple git status command
-        # fails, suggesting git is unavailable
+        # omit the optional 'git' API argument if git commands fail
         try:
-            run_command('git', 'status')
-        except CoverallsException:
-            log.warning('Failed collecting git data; `git status` {}.\nAre '
-                        'you running coveralls inside a git repository?')
+            rev = run_command('git', 'rev-parse', '--abbrev-ref',
+                              'HEAD').strip()
+            remotes = run_command('git', 'remote', '-v').splitlines()
+        except CoverallsException as ex:
+            log.warning('Failed collecting git data. Are you running '
+                        'coveralls inside a git repository?', exc_info=ex)
             return {}
 
-        rev = run_command('git', 'rev-parse', '--abbrev-ref', 'HEAD').strip()
-        remotes = run_command('git', 'remote', '-v').splitlines()
 
         return {
             'git': {

--- a/coveralls/api.py
+++ b/coveralls/api.py
@@ -272,11 +272,13 @@ class Coveralls(object):
                 }]
             }
         """
-        # silently omit the optional 'git' API argument if a simple git status
-        # command fails, suggesting git is unavailable
+        # omit the optional 'git' API argument if a simple git status command
+        # fails, suggesting git is unavailable
         try:
             run_command('git', 'status')
         except CoverallsException:
+            log.warning('Failed collecting git data; `git status` {}.\nAre '
+                        'you running coveralls inside a git repository?')
             return {}
 
         rev = run_command('git', 'rev-parse', '--abbrev-ref', 'HEAD').strip()


### PR DESCRIPTION
Tries to fix #174

Alternatively, we could require a flag or take the test out of the `git_info` method although it seems fitting imo.