### PR TITLE
Fix links to readthedocs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,5 +28,5 @@ Coveralls for python
 For more information and usage instructions, see our `documentation`_.
 
 .. _coveralls.io: https://coveralls.io/
-.. _coverage.py: https://coverage.readthedocs.io/en/coverage-4.4.1/
+.. _coverage.py: https://coverage.readthedocs.io/en/latest/
 .. _documentation: http://coveralls-python.readthedocs.io/en/latest/


### PR DESCRIPTION
The previous one produces a "Permission Denied" page for me.