### PR TITLE
Adds ability to add named job

### DIFF
--- a/coveralls/api.py
+++ b/coveralls/api.py
@@ -128,6 +128,10 @@ class Coveralls(object):
         if service_name:
             self.config['service_name'] = service_name
 
+        flag_name = os.environ.get('COVERALLS_FLAG_NAME')
+        if flag_name:
+            self.config['flag_name'] = flag_name
+
     def load_config_from_file(self):
         try:
             with open(os.path.join(os.getcwd(),


### PR DESCRIPTION
This PR adds support for a beta feature we are releasing soon on Coveralls which allows you to provide a flag name for jobs. 

Jobs with flag names will send additional GitHub statuses so you can track and know how coverage changed in separate areas whether that is unit/integration/E2E tests or backend/frontend.