### PR TITLE
SemaphoreCI support

### DIFF
--- a/coveralls/api.py
+++ b/coveralls/api.py
@@ -92,24 +92,32 @@ class Coveralls(object):
         return 'travis-ci', os.environ.get('TRAVIS_JOB_ID'), pr
 
     @staticmethod
+    def load_config_from_semaphore():
+        pr = os.environ.get('PULL_REQUEST_NUMBER')
+        return 'semaphore-ci', os.environ.get('SEMAPHORE_BUILD_NUMBER'), pr
+
+    @staticmethod
     def load_config_from_unknown():
         return 'coveralls-python', None, None
 
     def load_config_from_ci_environment(self):
         if os.environ.get('APPVEYOR'):
-            return self.load_config_from_appveyor()
-        if os.environ.get('BUILDKITE'):
-            return self.load_config_from_buildkite()
-        if os.environ.get('CIRCLECI'):
+            name, job, pr = self.load_config_from_appveyor()
+        elif os.environ.get('BUILDKITE'):
+            name, job, pr = self.load_config_from_buildkite()
+        elif os.environ.get('CIRCLECI'):
             self._token_required = False
-            return self.load_config_from_circle()
-        if os.environ.get('JENKINS_HOME'):
-            return self.load_config_from_jenkins()
-        if os.environ.get('TRAVIS'):
+            name, job, pr = self.load_config_from_circle()
+        elif os.environ.get('JENKINS_HOME'):
+            name, job, pr = self.load_config_from_jenkins()
+        elif os.environ.get('TRAVIS'):
             self._token_required = False
-            return self.load_config_from_travis()
-
-        return self.load_config_from_unknown()
+            name, job, pr = self.load_config_from_travis()
+        elif os.environ.get('SEMAPHORE'):
+            name, job, pr = self.load_config_from_semaphore()
+        else:
+            name, job, pr = self.load_config_from_unknown()
+        return (name, job, pr)
 
     def load_config_from_environment(self):
         coveralls_host = os.environ.get('COVERALLS_HOST')

--- a/coveralls/git.py
+++ b/coveralls/git.py
@@ -62,6 +62,7 @@ def git_info():
                   os.environ.get('CIRCLE_BRANCH') or
                   os.environ.get('GIT_BRANCH') or
                   os.environ.get('TRAVIS_BRANCH') or
+                  os.environ.get('BRANCH_NAME') or
                   run_command('git', 'rev-parse', '--abbrev-ref', 'HEAD'))
         head = {
             'id': gitlog('%H'),

--- a/docs/usage/tox.rst
+++ b/docs/usage/tox.rst
@@ -83,4 +83,17 @@ All variables:
 - ``TRAVIS_BRANCH``
 - ``TRAVIS_PULL_REQUEST``
 
+
+SemaphoreCI
+-------
+::
+
+    passenv = SEMAPHORE SEMAPHORE_BUILD_NUMBER BRANCH_NAME PULL_REQUEST_NUMBER
+
+All variables:
+
+- ``SEMAPHORE``
+- ``SEMAPHORE_BUILD_NUMBER``
+- ``BRANCH_NAME``
+- ``PULL_REQUEST_NUMBER``
 .. _tox: https://tox.readthedocs.io/en/latest/

--- a/tests/api/configuration_test.py
+++ b/tests/api/configuration_test.py
@@ -116,6 +116,17 @@ class NoConfiguration(unittest.TestCase):
         assert cover.config['service_job_id'] == '777'
         assert 'repo_token' not in cover.config
 
+    @mock.patch.dict(os.environ,
+                     {'SEMAPHORE': 'True',
+                      'SEMAPHORE_BUILD_NUMBER': '888',
+                      'PULL_REQUEST_NUMBER': '9999'},
+                     clear=True)
+    def test_semaphore_no_config(self):
+        cover = Coveralls(repo_token='xxx')
+        assert cover.config['service_name'] == 'semaphore-ci'
+        assert cover.config['service_job_id'] == '888'
+        assert cover.config['service_pull_request'] == '9999'
+
     @mock.patch.dict(os.environ, {'COVERALLS_SERVICE_NAME': 'xxx'}, clear=True)
     def test_service_name_from_env(self):
         cover = Coveralls(repo_token='yyy')


### PR DESCRIPTION
<!--
Pull requests with untested code will not be merged right away; if you would like to speed up the review process, please write tests.

Please make sure your PR passes our CI requirements. You can run these locally with

    pre-commit run --all-files
    tox

If your work affects the public-facing API or usage of this project, please make sure to update the relevant documentation.
-->
Added support for SemaphoreCI by parsing corresponding environment variables.

To avoid `pylint` failure:

```
R:103, 4: Too many return statements (7/6) (too-many-return-statements)
```

I changed the behavior of `load_config_from_ci_environment` to return only once in the end.