### PR TITLE
feat(api): support pull requests on buildkite

### DIFF
--- a/coveralls/api.py
+++ b/coveralls/api.py
@@ -74,7 +74,10 @@ class Coveralls(object):
 
     @staticmethod
     def load_config_from_buildkite():
-        return 'buildkite', os.environ.get('BUILDKITE_JOB_ID'), None
+        pr = os.environ.get('BUILDKITE_PULL_REQUEST')
+        if pr == 'false':
+            pr = None
+        return 'buildkite', os.environ.get('BUILDKITE_JOB_ID'), pr
 
     @staticmethod
     def load_config_from_circle():

--- a/tests/api/configuration_test.py
+++ b/tests/api/configuration_test.py
@@ -79,11 +79,22 @@ class NoConfiguration(unittest.TestCase):
         assert cover.config['service_pull_request'] == '1234'
 
     @mock.patch.dict(os.environ, {'BUILDKITE': 'True',
-                                  'BUILDKITE_JOB_ID': '1234567'}, clear=True)
+                                  'BUILDKITE_JOB_ID': '1234567',
+                                  'BUILDKITE_PULL_REQUEST': '1234'}, clear=True)
     def test_buildkite_no_config(self):
         cover = Coveralls(repo_token='xxx')
         assert cover.config['service_name'] == 'buildkite'
         assert cover.config['service_job_id'] == '1234567'
+        assert cover.config['service_pull_request'] == '1234'
+
+    @mock.patch.dict(os.environ, {'BUILDKITE': 'True',
+                                  'BUILDKITE_JOB_ID': '1234567',
+                                  'BUILDKITE_PULL_REQUEST': 'false'}, clear=True)
+    def test_buildkite_no_config_no_pr(self):
+        cover = Coveralls(repo_token='xxx')
+        assert cover.config['service_name'] == 'buildkite'
+        assert cover.config['service_job_id'] == '1234567'
+        assert 'service_pull_request' not in cover.config
 
     @mock.patch.dict(
         os.environ,


### PR DESCRIPTION
https://buildkite.com/docs/pipelines/environment-variables says that
the pull request is available via BUILDKITE_PULL_REQUEST, which is
either the number for a pull request, or "false" for a
non-pull-request.
