### PR TITLE
Added support for SSL verification disabling

### DIFF
--- a/coveralls/api.py
+++ b/coveralls/api.py
@@ -170,7 +170,8 @@ class Coveralls(object):
             return {}
 
         endpoint = '{}/api/v1/jobs'.format(self._coveralls_host.rstrip('/'))
-        response = requests.post(endpoint, files={'json_file': json_string})
+        verify = bool(os.environ.get('COVERALLS_SKIP_SSL_VERIFY'))
+        response = requests.post(endpoint, files={'json_file': json_string}, verify=verify)
         try:
             response.raise_for_status()
             return response.json()

--- a/coveralls/api.py
+++ b/coveralls/api.py
@@ -170,7 +170,7 @@ class Coveralls(object):
             return {}
 
         endpoint = '{}/api/v1/jobs'.format(self._coveralls_host.rstrip('/'))
-        verify = bool(os.environ.get('COVERALLS_SKIP_SSL_VERIFY'))
+        verify = not bool(os.environ.get('COVERALLS_SKIP_SSL_VERIFY'))
         response = requests.post(endpoint, files={'json_file': json_string}, verify=verify)
         try:
             response.raise_for_status()

--- a/coveralls/api.py
+++ b/coveralls/api.py
@@ -171,7 +171,8 @@ class Coveralls(object):
 
         endpoint = '{}/api/v1/jobs'.format(self._coveralls_host.rstrip('/'))
         verify = not bool(os.environ.get('COVERALLS_SKIP_SSL_VERIFY'))
-        response = requests.post(endpoint, files={'json_file': json_string}, verify=verify)
+        response = requests.post(endpoint, files={'json_file': json_string},
+                                 verify=verify)
         try:
             response.raise_for_status()
             return response.json()

--- a/tests/api/wear_test.py
+++ b/tests/api/wear_test.py
@@ -106,14 +106,14 @@ class WearTest(unittest.TestCase):
 
     @mock.patch.dict(
         os.environ,
-        {'COVERALLS_HOST': 'https://coveralls.my-enterprise.info'}, clear=True)
+        {'COVERALLS_HOST': 'https://coveralls.my-enterprise.info', 'COVERALLS_SKIP_SSL_VERIFY': '1'}, clear=True)
     def test_coveralls_host_env_var_overrides_api_url(self, mock_requests):
         coveralls.Coveralls(repo_token='xxx').wear(dry_run=False)
         mock_requests.post.assert_called_once_with(
-            'https://coveralls.my-enterprise.info/api/v1/jobs', files=mock.ANY)
+            'https://coveralls.my-enterprise.info/api/v1/jobs', files=mock.ANY, verify=False)
 
     @mock.patch.dict(os.environ, {}, clear=True)
     def test_api_call_uses_default_host_if_no_env_var_set(self, mock_requests):
         coveralls.Coveralls(repo_token='xxx').wear(dry_run=False)
         mock_requests.post.assert_called_once_with(
-            'https://coveralls.io/api/v1/jobs', files=mock.ANY)
+            'https://coveralls.io/api/v1/jobs', files=mock.ANY, verify=True)

--- a/tests/api/wear_test.py
+++ b/tests/api/wear_test.py
@@ -107,7 +107,7 @@ class WearTest(unittest.TestCase):
     @mock.patch.dict(
         os.environ,
         {'COVERALLS_HOST': 'https://coveralls.my-enterprise.info',
-            'COVERALLS_SKIP_SSL_VERIFY': '1'}, clear=True)
+         'COVERALLS_SKIP_SSL_VERIFY': '1'}, clear=True)
     def test_coveralls_host_env_var_overrides_api_url(self, mock_requests):
         coveralls.Coveralls(repo_token='xxx').wear(dry_run=False)
         mock_requests.post.assert_called_once_with(

--- a/tests/api/wear_test.py
+++ b/tests/api/wear_test.py
@@ -106,11 +106,13 @@ class WearTest(unittest.TestCase):
 
     @mock.patch.dict(
         os.environ,
-        {'COVERALLS_HOST': 'https://coveralls.my-enterprise.info', 'COVERALLS_SKIP_SSL_VERIFY': '1'}, clear=True)
+        {'COVERALLS_HOST': 'https://coveralls.my-enterprise.info',
+            'COVERALLS_SKIP_SSL_VERIFY': '1'}, clear=True)
     def test_coveralls_host_env_var_overrides_api_url(self, mock_requests):
         coveralls.Coveralls(repo_token='xxx').wear(dry_run=False)
         mock_requests.post.assert_called_once_with(
-            'https://coveralls.my-enterprise.info/api/v1/jobs', files=mock.ANY, verify=False)
+            'https://coveralls.my-enterprise.info/api/v1/jobs',
+            files=mock.ANY, verify=False)
 
     @mock.patch.dict(os.environ, {}, clear=True)
     def test_api_call_uses_default_host_if_no_env_var_set(self, mock_requests):


### PR DESCRIPTION
Coveralls Enterprise instances often use self-signed certificates

Using env var: `COVERALLS_SKIP_SSL_VERIFY`.



