### PR TITLE
Support github actions CI

### DIFF
--- a/coveralls/api.py
+++ b/coveralls/api.py
@@ -84,6 +84,13 @@ class Coveralls(object):
         return 'circle-ci', os.environ.get('CIRCLE_BUILD_NUM'), pr
 
     @staticmethod
+    def load_config_from_github():
+        pr = None
+        if os.environ.get('GITHUB_REF', '').startswith('refs/pull/'):
+            pr = os.environ.get('GITHUB_REF', '//').split('/')[2]
+        return 'github', None, pr
+
+    @staticmethod
     def load_config_from_jenkins():
         pr = os.environ.get('CI_PULL_REQUEST', '').split('/')[-1] or None
         return 'jenkins', os.environ.get('BUILD_NUMBER'), pr
@@ -110,6 +117,8 @@ class Coveralls(object):
         elif os.environ.get('CIRCLECI'):
             self._token_required = False
             name, job, pr = self.load_config_from_circle()
+        elif os.environ.get('GITHUB_ACTIONS'):
+            name, job, pr = self.load_config_from_github()
         elif os.environ.get('JENKINS_HOME'):
             name, job, pr = self.load_config_from_jenkins()
         elif os.environ.get('TRAVIS'):

--- a/docs/usage/configuration.rst
+++ b/docs/usage/configuration.rst
@@ -3,7 +3,7 @@
 Configuration
 =============
 
-coveralls-python often works without any outside configuration by examining the environment it is being run in. Special handling has been added for AppVeyor, BuildKite, CircleCI, Jenkins, and TravisCI to make coveralls-python as close to "plug and play" as possible.
+coveralls-python often works without any outside configuration by examining the environment it is being run in. Special handling has been added for AppVeyor, BuildKite, CircleCI, Github, Jenkins, and TravisCI to make coveralls-python as close to "plug and play" as possible.
 
 Most often, you will simply need to run coveralls-python with no additional options after you have run your coverage suite::
 

--- a/docs/usage/tox.rst
+++ b/docs/usage/tox.rst
@@ -56,6 +56,18 @@ All variables:
 - ``CIRCLE_BRANCH``
 - ``CI_PULL_REQUEST``
 
+Github
+---------
+::
+
+    passenv = GITHUB_*
+
+All variables:
+
+- ``GITHUB_ACTIONS``
+- ``GITHUB_REF``
+- ``GITHUB_HEAD_REF``
+
 Jenkins
 -------
 ::

--- a/tests/api/configuration_test.py
+++ b/tests/api/configuration_test.py
@@ -110,6 +110,26 @@ class NoConfiguration(unittest.TestCase):
         assert cover.config['service_job_id'] == '888'
         assert cover.config['service_pull_request'] == '9999'
 
+    @mock.patch.dict(os.environ, {'GITHUB_ACTIONS': 'true',
+                                  'GITHUB_REF': 'refs/pull/1234/merge',
+                                  'GITHUB_HEAD_REF': 'fixup-branch'},
+                     clear=True)
+    def test_github_no_config(self):
+        cover = Coveralls(repo_token='xxx')
+        assert cover.config['service_name'] == 'github'
+        assert cover.config['service_pull_request'] == '1234'
+        assert 'service_job_id' not in cover.config
+
+    @mock.patch.dict(os.environ, {'GITHUB_ACTIONS': 'true',
+                                  'GITHUB_REF': 'refs/heads/master',
+                                  'GITHUB_HEAD_REF': ''},
+                     clear=True)
+    def test_github_no_config_no_pr(self):
+        cover = Coveralls(repo_token='xxx')
+        assert cover.config['service_name'] == 'github'
+        assert 'service_pull_request' not in cover.config
+        assert 'service_job_id' not in cover.config
+
     @mock.patch.dict(
         os.environ,
         {'JENKINS_HOME': '/var/lib/jenkins',

--- a/tests/git_test.py
+++ b/tests/git_test.py
@@ -118,3 +118,24 @@ class GitInfoTestEnvVars(unittest.TestCase):
                 'branch': 'master',
             },
         }
+
+
+class GitInfoTestBranch(GitTest):
+    @mock.patch.dict(os.environ, {
+        'GITHUB_ACTIONS': 'true',
+        'GITHUB_REF': 'refs/pull/1234/merge',
+        'GITHUB_HEAD_REF': 'fixup-branch'
+    }, clear=True)
+    def test_gitinfo_github_pr(self):
+        git_info = coveralls.git.git_info()
+        print('git_info', git_info)
+        assert git_info['git']['branch'] == 'fixup-branch'
+
+    @mock.patch.dict(os.environ, {
+        'GITHUB_ACTIONS': 'true',
+        'GITHUB_REF': 'refs/heads/master',
+        'GITHUB_HEAD_REF': ''
+    }, clear=True)
+    def test_gitinfo_github_nopr(self):
+        git_info = coveralls.git.git_info()
+        assert git_info['git']['branch'] == 'master'


### PR DESCRIPTION
This adds support for CI running on [github actions](https://help.github.com/en/actions).

Getting the branch name is a little more tricky since the default way of repository cloning with actions/checkout puts you in a detached HEAD in which the regular `git rev-parse --abbrev-ref HEAD` returns _HEAD_ instead of the branch name.