### PR TITLE
fix(github): rename service to github-actions

### DIFF
--- a/coveralls/api.py
+++ b/coveralls/api.py
@@ -88,7 +88,7 @@ class Coveralls(object):
         pr = None
         if os.environ.get('GITHUB_REF', '').startswith('refs/pull/'):
             pr = os.environ.get('GITHUB_REF', '//').split('/')[2]
-        return 'github', None, pr
+        return 'github-actions', None, pr
 
     @staticmethod
     def load_config_from_jenkins():

--- a/docs/usage/configuration.rst
+++ b/docs/usage/configuration.rst
@@ -3,7 +3,7 @@
 Configuration
 =============
 
-coveralls-python often works without any outside configuration by examining the environment it is being run in. Special handling has been added for AppVeyor, BuildKite, CircleCI, Github, Jenkins, and TravisCI to make coveralls-python as close to "plug and play" as possible.
+coveralls-python often works without any outside configuration by examining the environment it is being run in. Special handling has been added for AppVeyor, BuildKite, CircleCI, Github Actions, Jenkins, and TravisCI to make coveralls-python as close to "plug and play" as possible.
 
 Most often, you will simply need to run coveralls-python with no additional options after you have run your coverage suite::
 

--- a/docs/usage/tox.rst
+++ b/docs/usage/tox.rst
@@ -56,8 +56,8 @@ All variables:
 - ``CIRCLE_BRANCH``
 - ``CI_PULL_REQUEST``
 
-Github
----------
+Github Actions
+--------------
 ::
 
     passenv = GITHUB_*

--- a/tests/api/configuration_test.py
+++ b/tests/api/configuration_test.py
@@ -116,7 +116,7 @@ class NoConfiguration(unittest.TestCase):
                      clear=True)
     def test_github_no_config(self):
         cover = Coveralls(repo_token='xxx')
-        assert cover.config['service_name'] == 'github'
+        assert cover.config['service_name'] == 'github-actions'
         assert cover.config['service_pull_request'] == '1234'
         assert 'service_job_id' not in cover.config
 
@@ -126,7 +126,7 @@ class NoConfiguration(unittest.TestCase):
                      clear=True)
     def test_github_no_config_no_pr(self):
         cover = Coveralls(repo_token='xxx')
-        assert cover.config['service_name'] == 'github'
+        assert cover.config['service_name'] == 'github-actions'
         assert 'service_pull_request' not in cover.config
         assert 'service_job_id' not in cover.config
 

--- a/tests/git_test.py
+++ b/tests/git_test.py
@@ -128,7 +128,6 @@ class GitInfoTestBranch(GitTest):
     }, clear=True)
     def test_gitinfo_github_pr(self):
         git_info = coveralls.git.git_info()
-        print('git_info', git_info)
         assert git_info['git']['branch'] == 'fixup-branch'
 
     @mock.patch.dict(os.environ, {


### PR DESCRIPTION
The coveralls API refuses to accept submissions with service=github, but accepts
submissions with service=github-actions.