### PR TITLE
feat: support coverage>=5.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,13 +13,26 @@ jobs:
       # TODO: figure out `<<parameters.docker_image>>.replace('.','')`
       tox_environment:
         type: string
+      cov_version:
+        default: ""
+        type: string
     steps:
       - run: apk add --no-cache gcc git libffi-dev musl-dev openssh-client openssl-dev
       - checkout
       - run: pip install tox tox-factor
-      - run: tox -f <<parameters.tox_environment>>
-      - run: tox -e coveralls
+      - unless:
+          condition: <<parameters.cov_version>>
+          steps:
+            - run: tox -f <<parameters.tox_environment>>
+            - run: tox -e coveralls41
+      - when:
+          condition: <<parameters.cov_version>>
+          steps:
+            - run: tox -f <<parameters.tox_environment>>-cov<<parameters.cov_version>>
+            - run: tox -e coveralls<<parameters.cov_version>>
 
+  # TODO: by introspecting `docker_image` (or `tox_environment`), we could
+  # these job definitions
   toxpypy:
     docker:
       - image: pypy:<<parameters.docker_image>>
@@ -29,11 +42,22 @@ jobs:
       # TODO: figure out `<<parameters.docker_image>>.replace('.','')`
       tox_environment:
         type: string
+      cov_version:
+        default: ""
+        type: string
     steps:
       - checkout
       - run: pip install tox tox-factor
-      - run: tox -f <<parameters.tox_environment>>
-      - run: tox -e coveralls
+      - unless:
+          condition: <<parameters.cov_version>>
+          steps:
+            - run: tox -f <<parameters.tox_environment>>
+            - run: tox -e coveralls41
+      - when:
+          condition: <<parameters.cov_version>>
+          steps:
+            - run: tox -f <<parameters.tox_environment>>-cov<<parameters.cov_version>>
+            - run: tox -e coveralls<<parameters.cov_version>>
 
 workflows:
   run-jobs:
@@ -54,17 +78,35 @@ workflows:
           docker_image: '3.5'
           tox_environment: py35
       - toxpy:
-          name: test-py3.6
+          name: test-py3.6-cov4
           docker_image: '3.6'
           tox_environment: py36
+          cov_version: '41'
       - toxpy:
-          name: test-py3.7
+          name: test-py3.6-cov5
+          docker_image: '3.6'
+          tox_environment: py36
+          cov_version: '5'
+      - toxpy:
+          name: test-py3.7-cov4
           docker_image: '3.7'
           tox_environment: py37
+          cov_version: '41'
       - toxpy:
-          name: test-py3.8
+          name: test-py3.7-cov5
+          docker_image: '3.7'
+          tox_environment: py37
+          cov_version: '5'
+      - toxpy:
+          name: test-py3.8-cov4
           docker_image: '3.8'
           tox_environment: py38
+          cov_version: '41'
+      - toxpy:
+          name: test-py3.8-cov5
+          docker_image: '3.8'
+          tox_environment: py38
+          cov_version: '5'
 
       - toxpypy:
           name: test-pypy2-5
@@ -80,14 +122,32 @@ workflows:
           tox_environment: pypy
 
       - toxpypy:
-          name: test-pypy3-5
+          name: test-pypy3-5-cov4
           docker_image: 3-5
           tox_environment: pypy3
+          cov_version: '41'
       - toxpypy:
-          name: test-pypy3-6
+          name: test-pypy3-5-cov5
+          docker_image: 3-5
+          tox_environment: pypy3
+          cov_version: '5'
+      - toxpypy:
+          name: test-pypy3-6-cov4
           docker_image: 3-6
           tox_environment: pypy3
+          cov_version: '41'
       - toxpypy:
-          name: test-pypy3-7
+          name: test-pypy3-6-cov5
+          docker_image: 3-6
+          tox_environment: pypy3
+          cov_version: '5'
+      - toxpypy:
+          name: test-pypy3-7-cov4
           docker_image: 3-7
-          tox_environment: pypy37
+          tox_environment: pypy3
+          cov_version: '41'
+      - toxpypy:
+          name: test-pypy3-7-cov5
+          docker_image: 3-7
+          tox_environment: pypy3
+          cov_version: '5'

--- a/coveralls/api.py
+++ b/coveralls/api.py
@@ -265,7 +265,7 @@ class Coveralls(object):
         else:
             workman.get_data()
 
-        return CoverallReporter(workman, workman.config).report()
+        return CoverallReporter(workman, workman.config).coverage
 
     @staticmethod
     def debug_bad_encoding(data):

--- a/coveralls/reporter.py
+++ b/coveralls/reporter.py
@@ -7,7 +7,6 @@ from coverage import __version__
 from coverage.misc import NoSource
 from coverage.misc import NotPython
 from coverage.phystokens import source_encoding
-from coverage.report import Reporter
 
 from .exception import CoverallsException
 
@@ -18,17 +17,23 @@ log = logging.getLogger('coveralls.reporter')
 class CoverallReporter(object):
     """Custom coverage.py reporter for coveralls.io"""
 
-    def __init__(self, *args, **kwargs):
-        self.source_files = []
-        self.reporter = Reporter(*args, **kwargs)
+    def __init__(self, cov, conf):
+        self.coverage = []
+        self.report(cov, conf)
 
-    def report(self, morfs=None):
+    def report(self, cov, conf, morfs=None):
         """
         Generate a part of json report for coveralls
 
         `morfs` is a list of modules or filenames.
         `outfile` is a file object to write the json to.
         """
+        try:
+            from coverage.report import Reporter
+            self.reporter = Reporter(cov, conf)
+        except ImportError:  # coverage >= 5.0
+            raise Exception('TODO: coverage v5 compatibility')
+
         units = None
         if hasattr(self.reporter, 'find_code_units'):
             self.reporter.find_code_units(morfs)
@@ -68,7 +73,7 @@ class CoverallReporter(object):
 
                 raise
 
-        return self.source_files
+        return self.coverage
 
     @staticmethod
     def get_hits(line_num, analysis):
@@ -162,4 +167,4 @@ class CoverallReporter(object):
         if branches:
             results['branches'] = branches
 
-        self.source_files.append(results)
+        self.coverage.append(results)

--- a/coveralls/reporter.py
+++ b/coveralls/reporter.py
@@ -21,6 +21,86 @@ class CoverallReporter(object):
         self.coverage = []
         self.report(cov, conf)
 
+    def report5(self, cov):
+        # N.B. this method is 99% copied from the coverage source code;
+        # unfortunately, the coverage v5 style of `get_analysis_to_report`
+        # errors out entirely if any source file has issues -- which would be a
+        # breaking change for us. In the interest of backwards compatibility,
+        # I've copied their code here so we can maintain the same `coveralls`
+        # API regardless of which `coverage` version is being used.
+        #
+        # TODO: deprecate the relevant APIs so we can just use the coverage
+        # public API directly.
+        #
+        # from coverage.report import get_analysis_to_report
+        # try:
+        #     for cu, analyzed in get_analysis_to_report(cov, None):
+        #         self.parse_file(cu, analyzed)
+        # except NoSource:
+        #     # Note that this behavior must necessarily change between
+        #     # coverage<5 and coverage>=5, as we are no longer interweaving
+        #     # with get_analysis_to_report (a single exception breaks the
+        #     # whole loop)
+        #     log.warning('No source for at least one file')
+        # except NotPython:
+        #     # Note that this behavior must necessarily change between
+        #     # coverage<5 and coverage>=5, as we are no longer interweaving
+        #     # with get_analysis_to_report (a single exception breaks the
+        #     # whole loop)
+        #     log.warning('A source file is not python')
+        # except CoverageException as e:
+        #     if str(e) != 'No data to report.':
+        #         raise
+
+        from coverage.files import FnmatchMatcher, prep_patterns
+
+        # get_analysis_to_report starts here; changes marked with TODOs
+        file_reporters = cov._get_file_reporters(None)  # pylint: disable=W0212
+        config = cov.config
+
+        if config.report_include:
+            matcher = FnmatchMatcher(prep_patterns(config.report_include))
+            file_reporters = [fr for fr in file_reporters
+                              if matcher.match(fr.filename)]
+
+        if config.report_omit:
+            matcher = FnmatchMatcher(prep_patterns(config.report_omit))
+            file_reporters = [fr for fr in file_reporters
+                              if not matcher.match(fr.filename)]
+
+        # TODO: deprecate changes
+        # if not file_reporters:
+        #     raise CoverageException("No data to report.")
+
+        for fr in sorted(file_reporters):
+            try:
+                analysis = cov._analyze(fr)  # pylint: disable=W0212
+            except NoSource:
+                if not config.ignore_errors:
+                    # TODO: deprecate changes
+                    # raise
+                    log.warning('No source for %s', fr.filename)
+            except NotPython:
+                # Only report errors for .py files, and only if we didn't
+                # explicitly suppress those errors.
+                # NotPython is only raised by PythonFileReporter, which has a
+                # should_be_python() method.
+                if fr.should_be_python():
+                    if config.ignore_errors:
+                        msg = "Couldn't parse Python file '{}'".format(
+                            fr.filename)
+                        cov._warn(msg,  # pylint: disable=W0212
+                                  slug="couldnt-parse")
+                    else:
+                        # TODO: deprecate changes
+                        # raise
+                        log.warning('Source file is not python %s',
+                                    fr.filename)
+            else:
+                # TODO: deprecate changes (well, this one is fine /shrug)
+                # yield (fr, analysis)
+                self.parse_file(fr, analysis)
+
     def report(self, cov, conf, morfs=None):
         """
         Generate a part of json report for coveralls
@@ -28,11 +108,12 @@ class CoverallReporter(object):
         `morfs` is a list of modules or filenames.
         `outfile` is a file object to write the json to.
         """
+        # pylint: disable=too-many-branches
         try:
             from coverage.report import Reporter
             self.reporter = Reporter(cov, conf)
         except ImportError:  # coverage >= 5.0
-            raise Exception('TODO: coverage v5 compatibility')
+            return self.report5(cov)
 
         units = None
         if hasattr(self.reporter, 'find_code_units'):
@@ -108,7 +189,14 @@ class CoverallReporter(object):
         if not analysis.has_arcs():
             return None
 
-        branch_lines = analysis.branch_lines()
+        if not hasattr(analysis, 'branch_lines'):
+            # N.B. switching to the public method analysis.missing_branch_arcs
+            # would work for half of what we need, but there doesn't seem to be
+            # an equivalent analysis.executed_branch_arcs
+            branch_lines = analysis._branch_lines()  # pylint: disable=W0212
+        else:
+            branch_lines = analysis.branch_lines()
+
         branches = []
 
         for l1, l2 in analysis.arcs_executed():

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         ],
     },
     install_requires=[
-        'coverage>=3.6,<5.0',
+        'coverage>=3.6,<6.0',
         'docopt>=0.6.1',
         'requests>=1.0.0',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -20,13 +20,13 @@ deps =
     cov3: coverage<4.0
     cov4: coverage>=4.0,<4.1
     cov41: coverage>=4.1,<5.0
-    cov5: coverage==5.0b1
+    cov5: coverage>=5.0,<6.0
 commands =
     coverage run --branch --source=coveralls -m pytest tests/
     coverage report -m
 
 [testenv:coveralls]
 deps =
-    coverage<5.0
+    coverage<6.0
 commands =
     coveralls --verbose

--- a/tox.ini
+++ b/tox.ini
@@ -5,9 +5,9 @@ envlist = py{27,34,35,py}-cov{3,4,41}-{default,pyyaml},py{36,37,38,py3}-cov{41,5
 python =
     2.7: py27
     3.5: py35
-    3.6: py36
-    3.7: py37
-    3.8: py38
+    3.6: py36-cov5
+    3.7: py37-cov5
+    3.8: py38-cov5
 
 [testenv]
 passenv = *
@@ -25,8 +25,14 @@ commands =
     coverage run --branch --source=coveralls -m pytest tests/
     coverage report -m
 
-[testenv:coveralls]
+[testenv:coveralls41]
 deps =
-    coverage<6.0
+    coverage>=4.1,<5.0
+commands =
+    coveralls --verbose
+
+[testenv:coveralls5]
+deps =
+    coverage>=5.0,<6.0
 commands =
     coveralls --verbose


### PR DESCRIPTION
I can't say I'm excited about this code, but at the very least this should be fully backwards compatible with how `coverage<5` + `coveralls` work together. There's definitely going to need to be some future work to clean this up, but hopefully this should be enough to get folks unblocked from using `coverage>=5.0`.

<!--
Pull requests with untested code will not be merged right away; if you would like to speed up the review process, please write tests.

Please make sure your PR passes our CI requirements. You can run these locally with

    pre-commit run --all-files
    tox

If your work affects the public-facing API or usage of this project, please make sure to update the relevant documentation.
-->