### PR TITLE
Update broken link to coverage.py docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -34,4 +34,4 @@ Administration
    release
 
 .. _coveralls.io: https://coveralls.io/
-.. _coverage.py: https://coverage.readthedocs.io/en/coverage-4.4.1/
+.. _coverage.py: https://coverage.readthedocs.io/en/latest/


### PR DESCRIPTION
Spotted while looking into #203. I see other parts of the documentation (https://coveralls-python.readthedocs.io/en/latest/tips/coveragerc.html) already link to the `latest` version, hence why I propose to link to it here as well.