### PR TITLE
fix version incompatibilites

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,6 +31,7 @@ repos:
         args:
         - --max-line-length=79
         - --ignore-imports=yes
+        - -d broad-except
         - -d fixme
         - -d import-error
         - -d invalid-name

--- a/coveralls/api.py
+++ b/coveralls/api.py
@@ -95,7 +95,7 @@ class Coveralls(object):
         pr = None
         if os.environ.get('GITHUB_REF', '').startswith('refs/pull/'):
             pr = os.environ.get('GITHUB_REF', '//').split('/')[2]
-            service_number += "-PR-{0}".format(pr)
+            service_number += '-PR-{0}'.format(pr)
         return 'github', service_number, pr
 
     @staticmethod

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
         'docopt>=0.6.1',
         'requests>=1.0.0',
     ],
-    tests_require=['mock', 'pytest', 'sh>=1.08'],
+    tests_require=['mock', 'pytest'],
     extras_require={
         'yaml': ['PyYAML>=3.10'],
         ':python_version < "3"': ['urllib3[secure]'],

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,9 @@ setup(
     ],
     tests_require=['mock', 'pytest'],
     extras_require={
-        'yaml': ['PyYAML>=3.10'],
+        # N.B. PyYAML 5.3 dropped support for Python 3.4... which we should
+        # also do...
+        'yaml': ['PyYAML>=3.10,<5.3'],
         ':python_version < "3"': ['urllib3[secure]'],
     },
     classifiers=[

--- a/tests/api/configuration_test.py
+++ b/tests/api/configuration_test.py
@@ -7,7 +7,6 @@ import unittest
 
 import mock
 import pytest
-import sh
 try:
     import yaml
 except ImportError:
@@ -22,7 +21,7 @@ class Configuration(unittest.TestCase):
     def setUp(self):
         self.dir = tempfile.mkdtemp()
 
-        sh.cd(self.dir)
+        os.chdir(self.dir)
         with open('.coveralls.mock', 'w+') as fp:
             fp.write('repo_token: xxx\n')
             fp.write('service_name: jenkins\n')

--- a/tests/api/encoding_test.py
+++ b/tests/api/encoding_test.py
@@ -2,11 +2,11 @@
 import json
 import logging
 import os
+import subprocess
 import sys
 
 import coverage
 import pytest
-import sh
 
 from coveralls import Coveralls
 
@@ -17,7 +17,7 @@ NONUNICODE_DIR = os.path.join(BASE_DIR, 'nonunicode')
 
 def test_non_unicode():
     os.chdir(NONUNICODE_DIR)
-    sh.coverage('run', 'nonunicode.py')
+    subprocess.call(['coverage', 'run', 'nonunicode.py'], cwd=NONUNICODE_DIR)
 
     actual_json = json.dumps(Coveralls(repo_token='xxx').get_coverage())
     expected_json_part = (
@@ -32,7 +32,7 @@ def test_non_unicode():
                     reason='coverage 4 not affected')
 def test_malformed_encoding_declaration(capfd):
     os.chdir(NONUNICODE_DIR)
-    sh.coverage('run', 'malformed.py')
+    subprocess.call(['coverage', 'run', 'malformed.py'], cwd=NONUNICODE_DIR)
 
     logging.getLogger('coveralls').addHandler(logging.StreamHandler())
     assert Coveralls(repo_token='xxx').get_coverage() == []
@@ -46,7 +46,7 @@ def test_malformed_encoding_declaration(capfd):
                     reason='coverage 3 fails')
 def test_malformed_encoding_declaration_py3_or_coverage4():
     os.chdir(NONUNICODE_DIR)
-    sh.coverage('run', 'malformed.py')
+    subprocess.call(['coverage', 'run', 'malformed.py'], cwd=NONUNICODE_DIR)
 
     result = Coveralls(repo_token='xxx').get_coverage()
     assert len(result) == 1

--- a/tests/api/wear_test.py
+++ b/tests/api/wear_test.py
@@ -8,7 +8,6 @@ import unittest
 import coverage
 import mock
 import pytest
-import sh
 
 import coveralls
 from coveralls.api import log
@@ -23,7 +22,10 @@ EXPECTED = {
 @mock.patch('coveralls.api.requests')
 class WearTest(unittest.TestCase):
     def setUp(self):
-        sh.rm('-f', '.coverage')
+        try:
+            os.remove('.coverage')
+        except Exception:
+            pass
 
     def test_wet_run(self, mock_requests):
         mock_requests.post.return_value.json.return_value = EXPECTED

--- a/tests/git_test.py
+++ b/tests/git_test.py
@@ -5,11 +5,11 @@ from __future__ import unicode_literals
 import os
 import re
 import shutil
+import subprocess
 import tempfile
 import unittest
 
 import mock
-import sh
 
 import coveralls.git
 
@@ -25,15 +25,18 @@ class GitTest(unittest.TestCase):
     def setUp(self):
         self.dir = tempfile.mkdtemp()
 
-        sh.cd(self.dir)
-        sh.touch('README')
+        os.chdir(self.dir)
+        open('README', 'a').close()
 
-        sh.git.init()
-        sh.git.config('user.name', '"{}"'.format(GIT_NAME))
-        sh.git.config('user.email', '"{}"'.format(GIT_EMAIL))
-        sh.git.add('README')
-        sh.git.commit('-m', GIT_COMMIT_MSG)
-        sh.git.remote('add', GIT_REMOTE, GIT_URL)
+        subprocess.call(['git', 'init'], cwd=self.dir)
+        subprocess.call(['git', 'config', 'user.name',
+                         '"{}"'.format(GIT_NAME)], cwd=self.dir)
+        subprocess.call(['git', 'config', 'user.email',
+                         '"{}"'.format(GIT_EMAIL)], cwd=self.dir)
+        subprocess.call(['git', 'add', 'README'], cwd=self.dir)
+        subprocess.call(['git', 'commit', '-m', GIT_COMMIT_MSG], cwd=self.dir)
+        subprocess.call(['git', 'remote', 'add', GIT_REMOTE, GIT_URL],
+                        cwd=self.dir)
 
     def tearDown(self):
         shutil.rmtree(self.dir)

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,6 @@ usedevelop = true
 deps =
     mock
     pytest
-    sh
     pyyaml: PyYAML>=3.10
     cov3: coverage<4.0
     cov4: coverage>=4.0,<4.1

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ usedevelop = true
 deps =
     mock
     pytest
-    pyyaml: PyYAML>=3.10
+    pyyaml: PyYAML>=3.10,<5.3
     cov3: coverage<4.0
     cov4: coverage>=4.0,<4.1
     cov41: coverage>=4.1,<5.0


### PR DESCRIPTION
Looks like PyPy2 and `sh` don't play nicely together -- bye bye `sh`!

Also seems like PyYAML has removed support for Py3.4. That's not unreasonable at all, but I'm going to continue supporting it for now, until a decent reason to avoid that. PyYAML's v5.3 release seems to be mostly stylistic in terms of its impact on us, so I'll stick with it for now.