### PR TITLE
chore: remove support for deprecated things

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,10 +66,6 @@ workflows:
           python_version: 3.7.5
 
       - toxpy:
-          name: test-py3.4
-          docker_image: '3.4'
-          tox_environment: py34
-      - toxpy:
           name: test-py3.5
           docker_image: '3.5'
           tox_environment: py35

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,10 +66,6 @@ workflows:
           python_version: 3.7.5
 
       - toxpy:
-          name: test-py2.7
-          docker_image: '2.7'
-          tox_environment: py27
-      - toxpy:
           name: test-py3.4
           docker_image: '3.4'
           tox_environment: py34
@@ -107,19 +103,6 @@ workflows:
           docker_image: '3.8'
           tox_environment: py38
           cov_version: '5'
-
-      - toxpypy:
-          name: test-pypy2-5
-          docker_image: 2-5
-          tox_environment: pypy
-      - toxpypy:
-          name: test-pypy2-6
-          docker_image: 2-6
-          tox_environment: pypy
-      - toxpypy:
-          name: test-pypy2-7
-          docker_image: 2-7
-          tox_environment: pypy
 
       - toxpypy:
           name: test-pypy3-5-cov4

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,11 +46,13 @@ jobs:
       - run: tox -e coveralls<<parameters.cov_version>>
 
 workflows:
-  run-jobs:
+  lint:
     jobs:
       - linter/pre-commit:
           python_version: 3.7.5
 
+  test-cpython:
+    jobs:
       - toxpy:
           name: test-py3.5
           docker_image: '3.5'
@@ -77,9 +79,21 @@ workflows:
             parameters:
               cov_version: ['41', '5']
 
+  test-pypy:
+    jobs:
       - toxpypy:
           name: test-pypy<<matrix.docker_image>>-cov<<matrix.cov_version>>
           matrix:
             parameters:
               cov_version: ['41', '5']
               docker_image: ['3-5', '3-6', '3-7']
+
+  test-alphaversions:
+    jobs:
+      - toxpy:
+          name: test-py3.9-alpha-cov<<matrix.cov_version>>
+          docker_image: '3.9.0a2'
+          tox_environment: py39
+          matrix:
+            parameters:
+              cov_version: ['41', '5']

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,13 +8,13 @@ jobs:
     docker:
       - image: python:<<parameters.docker_image>>-alpine
     parameters:
+      cov_version:
+        default: ""
+        type: string
       docker_image:
         type: string
       # TODO: figure out `<<parameters.docker_image>>.replace('.','')`
       tox_environment:
-        type: string
-      cov_version:
-        default: ""
         type: string
     steps:
       - run: apk add --no-cache gcc git libffi-dev musl-dev openssh-client openssl-dev
@@ -31,33 +31,19 @@ jobs:
             - run: tox -f <<parameters.tox_environment>>-cov<<parameters.cov_version>>
             - run: tox -e coveralls<<parameters.cov_version>>
 
-  # TODO: by introspecting `docker_image` (or `tox_environment`), we could
-  # these job definitions
   toxpypy:
     docker:
       - image: pypy:<<parameters.docker_image>>
     parameters:
-      docker_image:
-        type: string
-      # TODO: figure out `<<parameters.docker_image>>.replace('.','')`
-      tox_environment:
-        type: string
       cov_version:
-        default: ""
+        type: string
+      docker_image:
         type: string
     steps:
       - checkout
       - run: pip install tox tox-factor
-      - unless:
-          condition: <<parameters.cov_version>>
-          steps:
-            - run: tox -f <<parameters.tox_environment>>
-            - run: tox -e coveralls41
-      - when:
-          condition: <<parameters.cov_version>>
-          steps:
-            - run: tox -f <<parameters.tox_environment>>-cov<<parameters.cov_version>>
-            - run: tox -e coveralls<<parameters.cov_version>>
+      - run: tox -f pypy3-cov<<parameters.cov_version>>
+      - run: tox -e coveralls<<parameters.cov_version>>
 
 workflows:
   run-jobs:
@@ -70,63 +56,30 @@ workflows:
           docker_image: '3.5'
           tox_environment: py35
       - toxpy:
-          name: test-py3.6-cov4
+          name: test-py3.6-cov<<matrix.cov_version>>
           docker_image: '3.6'
           tox_environment: py36
-          cov_version: '41'
+          matrix:
+            parameters:
+              cov_version: ['41', '5']
       - toxpy:
-          name: test-py3.6-cov5
-          docker_image: '3.6'
-          tox_environment: py36
-          cov_version: '5'
-      - toxpy:
-          name: test-py3.7-cov4
+          name: test-py3.7-cov<<matrix.cov_version>>
           docker_image: '3.7'
           tox_environment: py37
-          cov_version: '41'
+          matrix:
+            parameters:
+              cov_version: ['41', '5']
       - toxpy:
-          name: test-py3.7-cov5
-          docker_image: '3.7'
-          tox_environment: py37
-          cov_version: '5'
-      - toxpy:
-          name: test-py3.8-cov4
+          name: test-py3.8-cov<<matrix.cov_version>>
           docker_image: '3.8'
           tox_environment: py38
-          cov_version: '41'
-      - toxpy:
-          name: test-py3.8-cov5
-          docker_image: '3.8'
-          tox_environment: py38
-          cov_version: '5'
+          matrix:
+            parameters:
+              cov_version: ['41', '5']
 
       - toxpypy:
-          name: test-pypy3-5-cov4
-          docker_image: 3-5
-          tox_environment: pypy3
-          cov_version: '41'
-      - toxpypy:
-          name: test-pypy3-5-cov5
-          docker_image: 3-5
-          tox_environment: pypy3
-          cov_version: '5'
-      - toxpypy:
-          name: test-pypy3-6-cov4
-          docker_image: 3-6
-          tox_environment: pypy3
-          cov_version: '41'
-      - toxpypy:
-          name: test-pypy3-6-cov5
-          docker_image: 3-6
-          tox_environment: pypy3
-          cov_version: '5'
-      - toxpypy:
-          name: test-pypy3-7-cov4
-          docker_image: 3-7
-          tox_environment: pypy3
-          cov_version: '41'
-      - toxpypy:
-          name: test-pypy3-7-cov5
-          docker_image: 3-7
-          tox_environment: pypy3
-          cov_version: '5'
+          name: test-pypy<<matrix.docker_image>>-cov<<matrix.cov_version>>
+          matrix:
+            parameters:
+              cov_version: ['41', '5']
+              docker_image: ['3-5', '3-6', '3-7']

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
+        python-version: [3.5, 3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v1

--- a/.gitignore
+++ b/.gitignore
@@ -1,104 +1,61 @@
-# Byte-compiled / optimized / DLL files
-__pycache__/
-*.py[cod]
 *$py.class
-
-# C extensions
-*.so
-
-# Distribution / packaging
-.Python
-build/
-develop-eggs/
-dist/
-downloads/
-eggs/
-.eggs/
-lib/
-lib64/
-parts/
-sdist/
-var/
-wheels/
-*.egg-info/
-.installed.cfg
-*.egg
-MANIFEST
-
-# PyInstaller
-#  Usually these files are written by a python script from a template
-#  before PyInstaller builds the exe, so as to inject date/other infos into it.
-*.manifest
-*.spec
-
-# Installer logs
-pip-log.txt
-pip-delete-this-directory.txt
-
-# Unit test / coverage reports
-htmlcov/
-.tox/
-.coverage
-.coverage.*
-.cache
-nosetests.xml
-coverage.xml
 *.cover
-.hypothesis/
-.pytest_cache/
-
-# Translations
+*.egg
+*.egg-info/
+*.log
+*.manifest
 *.mo
 *.pot
-
-# Django stuff:
-*.log
-local_settings.py
-db.sqlite3
-
-# Flask stuff:
-instance/
-.webassets-cache
-
-# Scrapy stuff:
-.scrapy
-
-# Sphinx documentation
-docs/_build/
-
-# PyBuilder
-target/
-
-# Jupyter Notebook
-.ipynb_checkpoints
-
-# pyenv
-.python-version
-
-# celery beat schedule file
-celerybeat-schedule
-
-# SageMath parsed files
+*.py[cod]
 *.sage.py
-
-# Environments
+*.so
+*.spec
+.Python
+.cache
+.coverage
+.coverage.*
+.eggs/
 .env
-.venv
-env/
-venv/
-ENV/
-env.bak/
-venv.bak/
-
-# Spyder project settings
+.hypothesis/
+.installed.cfg
+.ipynb_checkpoints
+.mypy_cache/
+.pytest_cache/
+.python-version
+.ropeproject
+.scrapy
 .spyderproject
 .spyproject
-
-# Rope project settings
-.ropeproject
-
-# mkdocs documentation
+.tox/
+.venv
+.webassets-cache
 /site
-
-# mypy
-.mypy_cache/
+ENV/
+MANIFEST
+__pycache__/
+build/
+celerybeat-schedule
+coverage.xml
+db.sqlite3
+develop-eggs/
+dist/
+docs/_build/
+downloads/
+eggs/
+env.bak/
+env/
+htmlcov/
+instance/
+lib/
+lib64/
+local_settings.py
+nosetests.xml
+parts/
+pip-delete-this-directory.txt
+pip-log.txt
+sdist/
+target/
+var/
+venv.bak/
+venv/
+wheels/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,82 +1,103 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.1.0
+    rev: v2.5.0
     hooks:
-    -   id: check-ast
-    -   id: check-builtin-literals
     -   id: check-case-conflict
     -   id: check-executables-have-shebangs
     -   id: check-json
     -   id: check-merge-conflict
     -   id: check-symlinks
+    -   id: check-toml
     -   id: check-vcs-permalinks
     -   id: check-xml
     -   id: check-yaml
         args: [--allow-multiple-documents]
-    -   id: debug-statements
     -   id: detect-private-key
     -   id: end-of-file-fixer
         exclude: example/.*
     -   id: file-contents-sorter
-        files: .dockerignore .gitignore
+        files: .(docker|git)ignore
     -   id: mixed-line-ending
         args: [--fix=lf]
+    -   id: trailing-whitespace
+
+# python
+    -   id: check-ast
+    -   id: check-builtin-literals
+    -   id: check-docstring-first
+    -   id: debug-statements
+    -   id: double-quote-string-fixer
+        exclude: nonunicode/.*
     -   id: name-tests-test
     -   id: requirements-txt-fixer
-    -   id: trailing-whitespace
 -   repo: https://github.com/pre-commit/mirrors-pylint
-    rev: v2.3.1
+    rev: v2.4.4
     hooks:
     -   id: pylint
+        additional_dependencies:
+        # TODO: >0.2.0
+        - git+https://github.com/bayesimpact/pylint_import_modules@016f79e4d2
         args:
+        - --allowed-direct-imports="typing.*"
+        - --load-plugins=pylint_import_modules
         - --max-line-length=79
         - --ignore-imports=yes
         - -d broad-except
         - -d fixme
         - -d import-error
+        - -d import-only-modules
         - -d invalid-name
         - -d locally-disabled
         - -d missing-docstring
         - -d too-few-public-methods
-        - -d useless-object-inheritance
+        - -d ungrouped-imports
         exclude: example/.*
 -   repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.1.6
+    rev: v1.1.7
     hooks:
     -   id: remove-tabs
 -   repo: https://github.com/asottile/reorder_python_imports
-    rev: v1.4.0
+    rev: v2.0.0
     hooks:
     -   id: reorder-python-imports
-        args: [--py26-plus]
-        files: coveralls/.*
+        args: [--py3-plus]
+        exclude: nonunicode/.*
+-   repo: https://github.com/asottile/pyupgrade
+    rev: v2.1.0
+    hooks:
+    -   id: pyupgrade
+        args: [--py3-plus]
+        exclude: nonunicode/.*
 -   repo: https://github.com/asottile/yesqa
-    rev: v0.0.10
+    rev: v1.1.0
     hooks:
     -   id: yesqa
         files: coveralls/.*
 -   repo: https://github.com/pre-commit/mirrors-autopep8
-    rev: v1.4.3
+    rev: v1.5
     hooks:
     -   id: autopep8
         files: coveralls/.*
 -   repo: https://github.com/PyCQA/pydocstyle
-    rev: 792b8d92  # TODO: >3.0.0
+    rev: 5.0.2
     hooks:
     -   id: pydocstyle
         args:
-        - --ignore=D1,D203,D205,D212,D400,D401,D404
+        - --ignore=D1,D203,D205,D212,D400,D401,D404,D413
         files: coveralls/.*
 -   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.7
+    rev: 3.7.9
     hooks:
     -   id: flake8
         args:
-        - --ignore=E501,W503,F811,F821
+        - --ignore=E501,W503,F401,F811
         files: coveralls/.*
 -   repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.2.0
+    rev: v1.5.1
     hooks:
+    -   id: python-no-eval
     -   id: python-no-log-warn
     -   id: python-use-type-annotations
+
+# rst
     -   id: rst-backticks

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,11 @@ sudo: false
 
 language: python
 python:
-  - 2.7
   - 3.4
   - 3.5
   - 3.6
   - 3.7
   - 3.8
-  - pypy
   - pypy3
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 
 language: python
 python:
-  - 3.4
   - 3.5
   - 3.6
   - 3.7

--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,9 @@ Coveralls for Python
     .. image:: https://img.shields.io/pypi/implementation/coveralls.svg?style=flat-square&label=Python%20Implementations
         :target: https://pypi.org/project/coveralls/
 
-`coveralls.io`_ is a service for publishing your coverage stats online. This package provides seamless integration with `coverage.py`_ (and thus ``pytest``, ``nosetests``, etc...) in your Python projects::
+`coveralls.io`_ is a service for publishing your coverage stats online. This
+package provides seamless integration with `coverage.py`_ (and thus ``pytest``,
+``nosetests``, etc...) in your Python projects::
 
     pip install coveralls
     coverage run --source=mypkg setup.py test
@@ -42,6 +44,24 @@ Coveralls for Python
 
 For more information and usage instructions, see our `documentation`_.
 
+Version Compatibility
+---------------------
+
+As of version 2.0, we have dropped support for end-of-life'd versions of Python
+and particularly old version of coverage. Support for non-EOL'd environments is
+provided on a best-effort basis and will generally be removed once they make
+maintenance too difficult.
+
+If you're running on an outdated environment with a new enough package manager
+to support version checks (see `the PyPA docs`_), then installing the latest
+compatible version should do the trick. If you're even more outdated than that,
+please pin to ``coveralls<2``.
+
+If you're in an outdated environment and experiencing an issue, feel free to
+open a ticket -- but please mention your environment! I'm willing to backport
+fixes to the 1.x branch if need be.
+
 .. _coveralls.io: https://coveralls.io/
 .. _coverage.py: https://coverage.readthedocs.io/en/latest/
 .. _documentation: http://coveralls-python.readthedocs.io/en/latest/
+.. _the PyPA docs: https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires

--- a/coveralls/__init__.py
+++ b/coveralls/__init__.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 from .api import Coveralls
 from .version import __version__
 

--- a/coveralls/api.py
+++ b/coveralls/api.py
@@ -268,11 +268,7 @@ class Coveralls:
         config_file = self.config.get('config_file', True)
         workman = coverage.coverage(config_file=config_file)
         workman.load()
-
-        if hasattr(workman, '_harvest_data'):
-            workman._harvest_data()  # pylint: disable=W0212
-        else:
-            workman.get_data()
+        workman.get_data()
 
         return CoverallReporter(workman, workman.config).coverage
 

--- a/coveralls/api.py
+++ b/coveralls/api.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 import codecs
 import json
 import logging

--- a/coveralls/api.py
+++ b/coveralls/api.py
@@ -15,11 +15,13 @@ from .reporter import CoverallReporter
 log = logging.getLogger('coveralls.api')
 
 
-class Coveralls(object):
+class Coveralls:
     config_filename = '.coveralls.yml'
 
     def __init__(self, token_required=True, service_name=None, **kwargs):
         """
+        Initialize the main Coveralls collection entrypoint.
+
         * repo_token
           The secret token for your repository, found at the bottom of your
           repository's page on Coveralls.
@@ -94,7 +96,7 @@ class Coveralls(object):
         pr = None
         if os.environ.get('GITHUB_REF', '').startswith('refs/pull/'):
             pr = os.environ.get('GITHUB_REF', '//').split('/')[2]
-            service_number += '-PR-{0}'.format(pr)
+            service_number += '-PR-{}'.format(pr)
         return 'github-actions', service_number, pr
 
     @staticmethod
@@ -162,12 +164,12 @@ class Coveralls(object):
             with open(os.path.join(os.getcwd(),
                                    self.config_filename)) as config:
                 try:
-                    import yaml
+                    import yaml  # pylint: disable=import-outside-toplevel
                     return yaml.safe_load(config)
                 except ImportError:
                     log.warning('PyYAML is not installed, skipping %s.',
                                 self.config_filename)
-        except (OSError, IOError):
+        except OSError:
             log.debug('Missing %s file. Using only env variables.',
                       self.config_filename)
 

--- a/coveralls/cli.py
+++ b/coveralls/cli.py
@@ -1,5 +1,5 @@
 """
-Publish coverage results online via coveralls.io
+Publish coverage results online via coveralls.io.
 
 Puts your coverage results on coveralls.io for everyone to see.
 
@@ -25,6 +25,7 @@ Global options:
     -v --verbose      Print extra info, always enabled when debugging.
 
 Example:
+-------
     $ coveralls
     Submitting coverage to coveralls.io...
     Coverage submitted!

--- a/coveralls/git.py
+++ b/coveralls/git.py
@@ -18,10 +18,7 @@ def run_command(*args):
             'command return code {}, STDOUT: "{}"\nSTDERR: "{}"'.format(
                 cmd.returncode, stdout, stderr))
 
-    try:
-        return stdout.decode().strip()
-    except UnicodeDecodeError:
-        return stdout.decode('utf-8').strip()
+    return stdout.decode().strip()
 
 
 def gitlog(fmt):

--- a/coveralls/git.py
+++ b/coveralls/git.py
@@ -28,10 +28,7 @@ def gitlog(fmt):
     glog = run_command('git', '--no-pager', 'log', '-1',
                        '--pretty=format:{}'.format(fmt))
 
-    try:
-        return str(glog)
-    except UnicodeEncodeError:
-        return unicode(glog)  # pylint: disable=undefined-variable
+    return str(glog)
 
 
 def git_branch():
@@ -62,6 +59,7 @@ def git_info():
     A hash of Git data that can be used to display more information to users.
 
     Example:
+    -------
         "git": {
             "head": {
                 "id": "5e837ce92220be64821128a70f6093f836dd2c05",

--- a/coveralls/reporter.py
+++ b/coveralls/reporter.py
@@ -140,9 +140,8 @@ class CoverallReporter(object):
                     log.warning('Source file is not python %s', cu.filename)
             except KeyError:
                 version = [int(x) for x in __version__.split('.')]
-                cov3x = version[0] < 4
                 cov40 = version[0] == 4 and version[1] < 1
-                if cov3x or cov40:
+                if cov40:
                     raise CoverallsException(
                         'Old (<4.1) versions of coverage.py do not work '
                         'consistently on new versions of Python. Please '

--- a/coveralls/reporter.py
+++ b/coveralls/reporter.py
@@ -1,12 +1,9 @@
-# coding: utf-8
 import logging
 import os
-import sys
 
 from coverage import __version__
 from coverage.misc import NoSource
 from coverage.misc import NotPython
-from coverage.phystokens import source_encoding
 
 from .exception import CoverallsException
 
@@ -216,18 +213,6 @@ class CoverallReporter(object):
             source_lines = analysis.parser.lines
             with cu.source_file() as source_file:
                 source = source_file.read()
-
-            try:
-                if sys.version_info < (3, 0):
-                    encoding = source_encoding(source)
-                    if encoding != 'utf-8':
-                        source = source.decode(encoding).encode('utf-8')
-            except UnicodeDecodeError:
-                log.warning(
-                    'Source file %s can not be properly decoded, skipping. '
-                    'Please check if encoding declaration is ok',
-                    os.path.basename(cu.filename))
-                return
         else:
             if hasattr(cu, 'relative_filename'):
                 filename = cu.relative_filename()

--- a/coveralls/reporter.py
+++ b/coveralls/reporter.py
@@ -11,8 +11,8 @@ from .exception import CoverallsException
 log = logging.getLogger('coveralls.reporter')
 
 
-class CoverallReporter(object):
-    """Custom coverage.py reporter for coveralls.io"""
+class CoverallReporter:
+    """Custom coverage.py reporter for coveralls.io."""
 
     def __init__(self, cov, conf):
         self.coverage = []
@@ -49,7 +49,7 @@ class CoverallReporter(object):
         #     if str(e) != 'No data to report.':
         #         raise
 
-        from coverage.files import FnmatchMatcher, prep_patterns
+        from coverage.files import FnmatchMatcher, prep_patterns  # pylint: disable=import-outside-toplevel
 
         # get_analysis_to_report starts here; changes marked with TODOs
         file_reporters = cov._get_file_reporters(None)  # pylint: disable=W0212
@@ -87,7 +87,7 @@ class CoverallReporter(object):
                         msg = "Couldn't parse Python file '{}'".format(
                             fr.filename)
                         cov._warn(msg,  # pylint: disable=W0212
-                                  slug="couldnt-parse")
+                                  slug='couldnt-parse')
                     else:
                         # TODO: deprecate changes
                         # raise
@@ -100,14 +100,14 @@ class CoverallReporter(object):
 
     def report(self, cov, conf, morfs=None):
         """
-        Generate a part of json report for coveralls
+        Generate a part of json report for coveralls.
 
         `morfs` is a list of modules or filenames.
         `outfile` is a file object to write the json to.
         """
         # pylint: disable=too-many-branches
         try:
-            from coverage.report import Reporter
+            from coverage.report import Reporter  # pylint: disable=import-outside-toplevel
             self.reporter = Reporter(cov, conf)
         except ImportError:  # coverage >= 5.0
             return self.report5(cov)
@@ -206,7 +206,7 @@ class CoverallReporter(object):
         return branches
 
     def parse_file(self, cu, analysis):
-        """Generate data for single file"""
+        """Generate data for single file."""
         if hasattr(analysis, 'parser'):
             filename = cu.file_locator.relative_filename(cu.filename)
             source_lines = analysis.parser.lines

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 from coveralls import __version__
 
 
-# -- General configuration ------------------------------------------------
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.githubpages',

--- a/docs/usage/tox.rst
+++ b/docs/usage/tox.rst
@@ -6,7 +6,7 @@ Running coveralls-python from within a `tox`_ environment (v2.0 and above) requi
 For example, on TravisCI::
 
     [tox]
-    envlist = py27,py34,py35,py36
+    envlist = py34,py35,py36,py37,py38
 
     [testenv]
     passenv = TRAVIS TRAVIS_*

--- a/example/__init__.py
+++ b/example/__init__.py
@@ -1,1 +1,0 @@
-# coding: utf-8

--- a/example/project.py
+++ b/example/project.py
@@ -1,6 +1,3 @@
-# coding: utf-8
-
-
 def hello():
     print('world')
 

--- a/example/project.py
+++ b/example/project.py
@@ -2,7 +2,7 @@ def hello():
     print('world')
 
 
-class Foo(object):
+class Foo:
     """ Bar """
 
 

--- a/example/runtests.py
+++ b/example/runtests.py
@@ -1,4 +1,5 @@
-from project import hello, branch
+from project import branch
+from project import hello
 
 if __name__ == '__main__':
     hello()

--- a/example/runtests.py
+++ b/example/runtests.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 from project import hello, branch
 
 if __name__ == '__main__':

--- a/nonunicode/__init__.py
+++ b/nonunicode/__init__.py
@@ -1,1 +1,0 @@
-# coding: utf-8

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ VERSION_FILE = os.path.join(os.path.abspath(os.path.dirname(__file__)),
 DESCRIPTION = open('README.rst').read()
 
 VERSION = None
-with open(VERSION_FILE, 'r') as f:
+with open(VERSION_FILE) as f:
     VERSION = f.read().split()[2][1:-1]
 
 

--- a/setup.py
+++ b/setup.py
@@ -39,9 +39,7 @@ setup(
     ],
     tests_require=['mock', 'pytest'],
     extras_require={
-        # N.B. PyYAML 5.3 dropped support for Python 3.4... which we should
-        # also do...
-        'yaml': ['PyYAML>=3.10,<5.3'],
+        'yaml': ['PyYAML>=3.10'],
     },
     classifiers=[
         'Development Status :: 5 - Production/Stable',
@@ -50,7 +48,6 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         ],
     },
     install_requires=[
-        'coverage>=3.6,<6.0',
+        'coverage>=4.0,<6.0',
         'docopt>=0.6.1',
         'requests>=1.0.0',
     ],

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
             'coveralls = coveralls.cli:main',
         ],
     },
+    python_requires='>= 3.5',
     install_requires=[
         'coverage>=4.1,<6.0',
         'docopt>=0.6.1',

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         ],
     },
     install_requires=[
-        'coverage>=4.0,<6.0',
+        'coverage>=4.1,<6.0',
         'docopt>=0.6.1',
         'requests>=1.0.0',
     ],

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,6 @@ setup(
         # N.B. PyYAML 5.3 dropped support for Python 3.4... which we should
         # also do...
         'yaml': ['PyYAML>=3.10,<5.3'],
-        ':python_version < "3"': ['urllib3[secure]'],
     },
     classifiers=[
         'Development Status :: 5 - Production/Stable',
@@ -51,7 +50,6 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,0 @@
-# coding: utf8

--- a/tests/api/__init__.py
+++ b/tests/api/__init__.py
@@ -1,1 +1,0 @@
-# coding: utf8

--- a/tests/api/configuration_test.py
+++ b/tests/api/configuration_test.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 # pylint: disable=no-self-use
 import os
 import shutil

--- a/tests/api/encoding_test.py
+++ b/tests/api/encoding_test.py
@@ -2,9 +2,6 @@ import json
 import os
 import subprocess
 
-import coverage
-import pytest
-
 from coveralls import Coveralls
 
 
@@ -24,8 +21,6 @@ def test_non_unicode():
     assert expected_json_part in actual_json
 
 
-@pytest.mark.skipif(coverage.__version__.startswith('3.'),
-                    reason='coverage 3 fails')
 def test_malformed_encoding_declaration_py3_or_coverage4():
     os.chdir(NONUNICODE_DIR)
     subprocess.call(['coverage', 'run', 'malformed.py'], cwd=NONUNICODE_DIR)

--- a/tests/api/encoding_test.py
+++ b/tests/api/encoding_test.py
@@ -1,9 +1,6 @@
-# coding: utf-8
 import json
-import logging
 import os
 import subprocess
-import sys
 
 import coverage
 import pytest
@@ -27,21 +24,6 @@ def test_non_unicode():
     assert expected_json_part in actual_json
 
 
-@pytest.mark.skipif(sys.version_info >= (3, 0), reason='python 3 not affected')
-@pytest.mark.skipif(coverage.__version__.startswith('4.'),
-                    reason='coverage 4 not affected')
-def test_malformed_encoding_declaration(capfd):
-    os.chdir(NONUNICODE_DIR)
-    subprocess.call(['coverage', 'run', 'malformed.py'], cwd=NONUNICODE_DIR)
-
-    logging.getLogger('coveralls').addHandler(logging.StreamHandler())
-    assert Coveralls(repo_token='xxx').get_coverage() == []
-
-    _, err = capfd.readouterr()
-    assert 'Source file malformed.py can not be properly decoded' in err
-
-
-@pytest.mark.skipif(sys.version_info < (3, 0), reason='python 2 fails')
 @pytest.mark.skipif(coverage.__version__.startswith('3.'),
                     reason='coverage 3 fails')
 def test_malformed_encoding_declaration_py3_or_coverage4():

--- a/tests/api/reporter_test.py
+++ b/tests/api/reporter_test.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 # pylint: disable=no-self-use
 import os
 import subprocess
@@ -38,8 +37,7 @@ class ReporterTest(unittest.TestCase):
         assert len(results) == 2
 
         assert_coverage(results[0], {
-            'source': ('# coding: utf-8\n\n\n'
-                       'def hello():\n'
+            'source': ('def hello():\n'
                        '    print(\'world\')\n\n\n'
                        'class Foo(object):\n'
                        '    """ Bar """\n\n\n'
@@ -49,20 +47,19 @@ class ReporterTest(unittest.TestCase):
                        '    if cond1:\n'
                        '        print(\'condition tested both ways\')\n'
                        '    if cond2:\n'
-                       '        print(\'condition not tested both ways\')'),
+                       '        print(\'condition not tested both ways\')\n'),
             'name': 'project.py',
-            'coverage': [None, None, None, 1, 1, None, None, 1, None, None,
+            'coverage': [1, 1, None, None, 1, None, None,
                          None, 1, 0, None, 1, 1, 1, 1, 1]})
 
         assert_coverage(results[1], {
-            'source': ('# coding: utf-8\n'
-                       'from project import hello, branch\n\n'
+            'source': ('from project import hello, branch\n\n'
                        "if __name__ == '__main__':\n"
                        '    hello()\n'
                        '    branch(False, True)\n'
-                       '    branch(True, True)'),
+                       '    branch(True, True)\n'),
             'name': 'runtests.py',
-            'coverage': [None, 1, None, 1, 1, 1, 1]})
+            'coverage': [1, None, 1, 1, 1, 1]})
 
     def test_reporter_with_branches(self):
         subprocess.call(['coverage', 'run', '--branch', '--omit=**/.tox/*',
@@ -75,8 +72,7 @@ class ReporterTest(unittest.TestCase):
         assert not len(results[1]['branches']) % 4
 
         assert_coverage(results[0], {
-            'source': ('# coding: utf-8\n\n\n'
-                       'def hello():\n'
+            'source': ('def hello():\n'
                        '    print(\'world\')\n\n\n'
                        'class Foo(object):\n'
                        '    """ Bar """\n\n\n'
@@ -86,23 +82,22 @@ class ReporterTest(unittest.TestCase):
                        '    if cond1:\n'
                        '        print(\'condition tested both ways\')\n'
                        '    if cond2:\n'
-                       '        print(\'condition not tested both ways\')'),
+                       '        print(\'condition not tested both ways\')\n'),
             'name': 'project.py',
-            'branches': [16, 0, 17, 1, 16, 0, 18, 1, 18, 0, 19, 1, 18, 0, 15,
+            'branches': [13, 0, 14, 1, 13, 0, 15, 1, 15, 0, 16, 1, 15, 0, 12,
                          0],
-            'coverage': [None, None, None, 1, 1, None, None, 1, None, None,
+            'coverage': [1, 1, None, None, 1, None, None,
                          None, 1, 0, None, 1, 1, 1, 1, 1]})
 
         assert_coverage(results[1], {
-            'source': ('# coding: utf-8\n'
-                       'from project import hello, branch\n\n'
+            'source': ('from project import hello, branch\n\n'
                        "if __name__ == '__main__':\n"
                        '    hello()\n'
                        '    branch(False, True)\n'
-                       '    branch(True, True)'),
+                       '    branch(True, True)\n'),
             'name': 'runtests.py',
-            'branches': [4, 0, 5, 1, 4, 0, 2, 0],
-            'coverage': [None, 1, None, 1, 1, 1, 1]})
+            'branches': [3, 0, 4, 1, 3, 0, 1, 0],
+            'coverage': [1, None, 1, 1, 1, 1]})
 
     def test_missing_file(self):
         with open('extra.py', 'w') as f:

--- a/tests/api/reporter_test.py
+++ b/tests/api/reporter_test.py
@@ -39,7 +39,7 @@ class ReporterTest(unittest.TestCase):
         assert_coverage(results[0], {
             'source': ('def hello():\n'
                        '    print(\'world\')\n\n\n'
-                       'class Foo(object):\n'
+                       'class Foo:\n'
                        '    """ Bar """\n\n\n'
                        'def baz():\n'
                        '    print(\'this is not tested\')\n\n'
@@ -53,13 +53,14 @@ class ReporterTest(unittest.TestCase):
                          None, 1, 0, None, 1, 1, 1, 1, 1]})
 
         assert_coverage(results[1], {
-            'source': ('from project import hello, branch\n\n'
+            'source': ('from project import branch\n'
+                       'from project import hello\n\n'
                        "if __name__ == '__main__':\n"
                        '    hello()\n'
                        '    branch(False, True)\n'
                        '    branch(True, True)\n'),
             'name': 'runtests.py',
-            'coverage': [1, None, 1, 1, 1, 1]})
+            'coverage': [1, 1, None, 1, 1, 1, 1]})
 
     def test_reporter_with_branches(self):
         subprocess.call(['coverage', 'run', '--branch', '--omit=**/.tox/*',
@@ -74,7 +75,7 @@ class ReporterTest(unittest.TestCase):
         assert_coverage(results[0], {
             'source': ('def hello():\n'
                        '    print(\'world\')\n\n\n'
-                       'class Foo(object):\n'
+                       'class Foo:\n'
                        '    """ Bar """\n\n\n'
                        'def baz():\n'
                        '    print(\'this is not tested\')\n\n'
@@ -90,14 +91,15 @@ class ReporterTest(unittest.TestCase):
                          None, 1, 0, None, 1, 1, 1, 1, 1]})
 
         assert_coverage(results[1], {
-            'source': ('from project import hello, branch\n\n'
+            'source': ('from project import branch\n'
+                       'from project import hello\n\n'
                        "if __name__ == '__main__':\n"
                        '    hello()\n'
                        '    branch(False, True)\n'
                        '    branch(True, True)\n'),
             'name': 'runtests.py',
-            'branches': [3, 0, 4, 1, 3, 0, 1, 0],
-            'coverage': [1, None, 1, 1, 1, 1]})
+            'branches': [4, 0, 5, 1, 4, 0, 1, 0],
+            'coverage': [1, 1, None, 1, 1, 1, 1]})
 
     def test_missing_file(self):
         with open('extra.py', 'w') as f:

--- a/tests/api/wear_test.py
+++ b/tests/api/wear_test.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 # pylint: disable=no-self-use
 import json
 import os

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -2,6 +2,7 @@ import json
 import os
 
 import mock
+
 from coveralls import Coveralls
 
 

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 import json
 import os
 

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 import os
 
 import mock

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+import os
+
+import pytest
+
+
+@pytest.fixture(scope='session', autouse=True)
+def nuke_coverage():
+    for folder in ('.', './example', './nonunicode'):
+        try:
+            os.remove('{}/.coverage'.format(folder))
+        except FileNotFoundError:
+            pass

--- a/tests/git_test.py
+++ b/tests/git_test.py
@@ -1,7 +1,4 @@
-# coding: utf-8
 # pylint: disable=no-self-use
-from __future__ import unicode_literals
-
 import os
 import re
 import shutil
@@ -77,28 +74,17 @@ class GitLogTest(GitTest):
         assert coveralls.git.gitlog('%s') == GIT_COMMIT_MSG
 
 
-def correct_encoding_for_envvars(value):
-    """
-    Env vars are unicode in Python 3 but bytes in Python 2
-    """
-    try:
-        str(value)
-    except UnicodeEncodeError:
-        value = value.encode('utf8')
-    return value
-
-
 class GitInfoTestEnvVars(unittest.TestCase):
     @mock.patch.dict(os.environ, {
         'GIT_ID': '5e837ce92220be64821128a70f6093f836dd2c05',
         'GIT_BRANCH': 'master',
-        'GIT_AUTHOR_NAME': correct_encoding_for_envvars(GIT_NAME),
-        'GIT_AUTHOR_EMAIL': correct_encoding_for_envvars(GIT_EMAIL),
-        'GIT_COMMITTER_NAME': correct_encoding_for_envvars(GIT_NAME),
-        'GIT_COMMITTER_EMAIL': correct_encoding_for_envvars(GIT_EMAIL),
-        'GIT_MESSAGE': correct_encoding_for_envvars(GIT_COMMIT_MSG),
-        'GIT_URL': correct_encoding_for_envvars(GIT_URL),
-        'GIT_REMOTE': correct_encoding_for_envvars(GIT_REMOTE),
+        'GIT_AUTHOR_NAME': GIT_NAME,
+        'GIT_AUTHOR_EMAIL': GIT_EMAIL,
+        'GIT_COMMITTER_NAME': GIT_NAME,
+        'GIT_COMMITTER_EMAIL': GIT_EMAIL,
+        'GIT_MESSAGE': GIT_COMMIT_MSG,
+        'GIT_URL': GIT_URL,
+        'GIT_REMOTE': GIT_REMOTE,
     }, clear=True)
     def test_gitlog_envvars(self):
         git_info = coveralls.git.git_info()
@@ -108,15 +94,15 @@ class GitInfoTestEnvVars(unittest.TestCase):
         assert git_info == {
             'git': {
                 'head': {
-                    'committer_email': correct_encoding_for_envvars(GIT_EMAIL),
-                    'author_email': correct_encoding_for_envvars(GIT_EMAIL),
-                    'author_name': correct_encoding_for_envvars(GIT_NAME),
-                    'message': correct_encoding_for_envvars(GIT_COMMIT_MSG),
-                    'committer_name': correct_encoding_for_envvars(GIT_NAME),
+                    'committer_email': GIT_EMAIL,
+                    'author_email': GIT_EMAIL,
+                    'author_name': GIT_NAME,
+                    'message': GIT_COMMIT_MSG,
+                    'committer_name': GIT_NAME,
                 },
                 'remotes': [{
-                    'url': correct_encoding_for_envvars(GIT_URL),
-                    'name': correct_encoding_for_envvars(GIT_REMOTE),
+                    'url': GIT_URL,
+                    'name': GIT_REMOTE,
                 }],
                 'branch': 'master',
             },

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{34,35}-cov{41}-{default,pyyaml},py{36,37,38,py3}-cov{41,5}-{default,pyyaml}
+envlist = py35-cov41-{default,pyyaml},py{36,37,38,py3}-cov{41,5}-{default,pyyaml}
 
 [gh-actions]
 python =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{34,35}-cov{3,4,41}-{default,pyyaml},py{36,37,38,py3}-cov{41,5}-{default,pyyaml}
+envlist = py{34,35}-cov{4,41}-{default,pyyaml},py{36,37,38,py3}-cov{41,5}-{default,pyyaml}
 
 [gh-actions]
 python =
@@ -15,7 +15,6 @@ deps =
     mock
     pytest
     pyyaml: PyYAML>=3.10,<5.3
-    cov3: coverage<4.0
     cov4: coverage>=4.0,<4.1
     cov41: coverage>=4.1,<5.0
     cov5: coverage>=5.0,<6.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{34,35}-cov{4,41}-{default,pyyaml},py{36,37,38,py3}-cov{41,5}-{default,pyyaml}
+envlist = py{34,35}-cov{41}-{default,pyyaml},py{36,37,38,py3}-cov{41,5}-{default,pyyaml}
 
 [gh-actions]
 python =
@@ -15,7 +15,6 @@ deps =
     mock
     pytest
     pyyaml: PyYAML>=3.10,<5.3
-    cov4: coverage>=4.0,<4.1
     cov41: coverage>=4.1,<5.0
     cov5: coverage>=5.0,<6.0
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35-cov41-{default,pyyaml},py{36,37,38,py3}-cov{41,5}-{default,pyyaml}
+envlist = py35-cov41-{default,pyyaml},py{36,37,38,39,py3}-cov{41,5}-{default,pyyaml}
 
 [gh-actions]
 python =

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,8 @@
 [tox]
-envlist = py{27,34,35,py}-cov{3,4,41}-{default,pyyaml},py{36,37,38,py3}-cov{41,5}-{default,pyyaml}
+envlist = py{34,35}-cov{3,4,41}-{default,pyyaml},py{36,37,38,py3}-cov{41,5}-{default,pyyaml}
 
 [gh-actions]
 python =
-    2.7: py27
     3.5: py35
     3.6: py36-cov5
     3.7: py37-cov5


### PR DESCRIPTION
I think it's about time to remove support for these -- they've started to cause compatibility issues with libraries and are making this code hard to maintain. We can release this as a major version bump and any users in outdated environments can simply continue to use `coveralls<2.0`.

Nukes support for:
* Python 2.7 and 3.4
* Coverage 3.x and 4.0.x

Also cleans up a whole bunch of no-longer-necessary code and makes it a bit easier to add tests for pre-alpha things (eg. Py39).

<!--
Pull requests with untested code will not be merged right away; if you would like to speed up the review process, please write tests.

Please make sure your PR passes our CI requirements. You can run these locally with

    pre-commit run --all-files
    tox

If your work affects the public-facing API or usage of this project, please make sure to update the relevant documentation.
-->