### PR TITLE
Update Github Actions support

### DIFF
--- a/coveralls/api.py
+++ b/coveralls/api.py
@@ -49,16 +49,12 @@ class Coveralls:
 
         self.load_config_from_environment()
 
-        name, job, pr = self.load_config_from_ci_environment()
+        name, job, number, pr = self.load_config_from_ci_environment()
         self.config['service_name'] = self.config.get('service_name', name)
         if job:
-            # N.B. Github Actions uses a different chunk of the Coveralls
-            # config when running parallel builds, ie. `service_number` instead
-            # of `service_job_id`.
-            if name.startswith('github'):
-                self.config['service_number'] = job
-            else:
-                self.config['service_job_id'] = job
+            self.config['service_job_id'] = job
+        if number:
+            self.config['service_number'] = number
         if pr:
             self.config['service_pull_request'] = pr
 
@@ -76,67 +72,78 @@ class Coveralls:
     @staticmethod
     def load_config_from_appveyor():
         pr = os.environ.get('APPVEYOR_PULL_REQUEST_NUMBER')
-        return 'appveyor', os.environ.get('APPVEYOR_BUILD_ID'), pr
+        return 'appveyor', os.environ.get('APPVEYOR_BUILD_ID'), None, pr
 
     @staticmethod
     def load_config_from_buildkite():
         pr = os.environ.get('BUILDKITE_PULL_REQUEST')
         if pr == 'false':
             pr = None
-        return 'buildkite', os.environ.get('BUILDKITE_JOB_ID'), pr
+        return 'buildkite', os.environ.get('BUILDKITE_JOB_ID'), None, pr
 
     @staticmethod
     def load_config_from_circle():
         pr = os.environ.get('CI_PULL_REQUEST', '').split('/')[-1] or None
-        return 'circle-ci', os.environ.get('CIRCLE_BUILD_NUM'), pr
+        return 'circle-ci', os.environ.get('CIRCLE_BUILD_NUM'), None, pr
 
-    @staticmethod
-    def load_config_from_github():
-        service_number = os.environ.get('GITHUB_SHA')
+    def load_config_from_github(self):
+        service = 'github'
+        if self.config.get('repo_token'):
+            service = 'github-actions'
+        else:
+            gh_token = os.environ.get('GITHUB_TOKEN')
+            if not gh_token:
+                raise CoverallsException(
+                    'Running on Github Actions but GITHUB_TOKEN is not set. '
+                    'Add "env: GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}" to '
+                    'your step config.')
+            self.config['repo_token'] = gh_token
+
+        number = os.environ.get('GITHUB_RUN_ID')
         pr = None
         if os.environ.get('GITHUB_REF', '').startswith('refs/pull/'):
             pr = os.environ.get('GITHUB_REF', '//').split('/')[2]
-            service_number += '-PR-{}'.format(pr)
-        return 'github-actions', service_number, pr
+        return service, None, number, pr
 
     @staticmethod
     def load_config_from_jenkins():
         pr = os.environ.get('CI_PULL_REQUEST', '').split('/')[-1] or None
-        return 'jenkins', os.environ.get('BUILD_NUMBER'), pr
+        return 'jenkins', os.environ.get('BUILD_NUMBER'), None, pr
 
     @staticmethod
     def load_config_from_travis():
         pr = os.environ.get('TRAVIS_PULL_REQUEST')
-        return 'travis-ci', os.environ.get('TRAVIS_JOB_ID'), pr
+        return 'travis-ci', os.environ.get('TRAVIS_JOB_ID'), None, pr
 
     @staticmethod
     def load_config_from_semaphore():
+        job = os.environ.get('SEMAPHORE_BUILD_NUMBER')
         pr = os.environ.get('PULL_REQUEST_NUMBER')
-        return 'semaphore-ci', os.environ.get('SEMAPHORE_BUILD_NUMBER'), pr
+        return 'semaphore-ci', job, None, pr
 
     @staticmethod
     def load_config_from_unknown():
-        return 'coveralls-python', None, None
+        return 'coveralls-python', None, None, None
 
     def load_config_from_ci_environment(self):
         if os.environ.get('APPVEYOR'):
-            name, job, pr = self.load_config_from_appveyor()
+            name, job, number, pr = self.load_config_from_appveyor()
         elif os.environ.get('BUILDKITE'):
-            name, job, pr = self.load_config_from_buildkite()
+            name, job, number, pr = self.load_config_from_buildkite()
         elif os.environ.get('CIRCLECI'):
-            name, job, pr = self.load_config_from_circle()
+            name, job, number, pr = self.load_config_from_circle()
         elif os.environ.get('GITHUB_ACTIONS'):
-            name, job, pr = self.load_config_from_github()
+            name, job, number, pr = self.load_config_from_github()
         elif os.environ.get('JENKINS_HOME'):
-            name, job, pr = self.load_config_from_jenkins()
+            name, job, number, pr = self.load_config_from_jenkins()
         elif os.environ.get('TRAVIS'):
             self._token_required = False
-            name, job, pr = self.load_config_from_travis()
+            name, job, number, pr = self.load_config_from_travis()
         elif os.environ.get('SEMAPHORE'):
-            name, job, pr = self.load_config_from_semaphore()
+            name, job, number, pr = self.load_config_from_semaphore()
         else:
-            name, job, pr = self.load_config_from_unknown()
-        return (name, job, pr)
+            name, job, number, pr = self.load_config_from_unknown()
+        return (name, job, number, pr)
 
     def load_config_from_environment(self):
         coveralls_host = os.environ.get('COVERALLS_HOST')
@@ -158,6 +165,10 @@ class Coveralls:
         flag_name = os.environ.get('COVERALLS_FLAG_NAME')
         if flag_name:
             self.config['flag_name'] = flag_name
+
+        number = os.environ.get('COVERALLS_SERVICE_JOB_NUMBER')
+        if number:
+            self.config['service_number'] = number
 
     def load_config_from_file(self):
         try:

--- a/coveralls/cli.py
+++ b/coveralls/cli.py
@@ -21,6 +21,7 @@ Global options:
     --rcfile=<file>   Specify configuration file. [default: .coveragerc]
     --output=<file>   Write report to file. Doesn't send anything.
     --merge=<file>    Merge report from file when submitting.
+    --finish          Finish parallel jobs.
     -h --help         Display this help.
     -v --verbose      Print extra info, always enabled when debugging.
 
@@ -72,6 +73,12 @@ def main(argv=None):
         if options['--output']:
             log.info('Write coverage report to file...')
             coverallz.save_report(options['--output'])
+            return
+
+        if options['--finish']:
+            log.info('Finishing parallel jobs...')
+            coverallz.parallel_finish()
+            log.info('Done')
             return
 
         log.info('Submitting coverage to coveralls.io...')

--- a/coveralls/exception.py
+++ b/coveralls/exception.py
@@ -1,2 +1,8 @@
 class CoverallsException(Exception):
-    pass
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return str(self) == str(other)
+        return False
+
+    def __ne__(self, other):
+        return not self.__eq__(other)

--- a/docs/usage/tox.rst
+++ b/docs/usage/tox.rst
@@ -68,6 +68,8 @@ All variables:
 - ``GITHUB_REF``
 - ``GITHUB_SHA``
 - ``GITHUB_HEAD_REF``
+- ``GITHUB_RUN_ID``
+- ``GITHUB_TOKEN``
 
 Jenkins
 -------

--- a/docs/usage/tox.rst
+++ b/docs/usage/tox.rst
@@ -68,6 +68,7 @@ All variables:
 - ``GITHUB_REF``
 - ``GITHUB_SHA``
 - ``GITHUB_HEAD_REF``
+- ``GITHUB_REPOSITORY``
 - ``GITHUB_RUN_ID``
 - ``GITHUB_TOKEN``
 

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
         'docopt>=0.6.1',
         'requests>=1.0.0',
     ],
-    tests_require=['mock', 'pytest'],
+    tests_require=['mock', 'responses', 'pytest'],
     extras_require={
         'yaml': ['PyYAML>=3.10'],
     },

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -18,6 +18,7 @@ def test_debug(mock_wear, mock_log):
     mock_log.assert_has_calls([mock.call('Testing coveralls-python...')])
 
 
+@mock.patch.dict(os.environ, clear=True)
 @mock.patch.object(coveralls.cli.log, 'info')
 @mock.patch.object(coveralls.Coveralls, 'wear')
 def test_debug_no_token(mock_wear, mock_log):
@@ -74,6 +75,7 @@ def test_save_report_to_file(mock_coveralls):
     mock_coveralls.assert_called_with('test.log')
 
 
+@mock.patch.dict(os.environ, clear=True)
 @mock.patch.object(coveralls.Coveralls, 'save_report')
 def test_save_report_to_file_no_token(mock_coveralls):
     """Check save_report api usage when token is not set."""

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -1,12 +1,18 @@
+import json
 import os
 
 import mock
+import responses
 
 import coveralls.cli
 from coveralls.exception import CoverallsException
 
 
 EXC = CoverallsException('bad stuff happened')
+
+
+def req_json(request):
+    return json.loads(request.body.decode('utf-8'))
 
 
 @mock.patch.dict(os.environ, {'TRAVIS': 'True'}, clear=True)
@@ -25,6 +31,61 @@ def test_debug_no_token(mock_wear, mock_log):
     coveralls.cli.main(argv=['debug'])
     mock_wear.assert_called_with(dry_run=True)
     mock_log.assert_has_calls([mock.call('Testing coveralls-python...')])
+
+
+@mock.patch.dict(
+    os.environ,
+    {'GITHUB_ACTIONS': 'true',
+     'GITHUB_REPOSITORY': 'test/repo',
+     'GITHUB_TOKEN': 'xxx',
+     'GITHUB_RUN_ID': '123456789',
+     'GITHUB_RUN_NUMBER': '123'},
+    clear=True)
+@mock.patch.object(coveralls.cli.log, 'info')
+@responses.activate
+def test_finish(mock_log):
+    responses.add(responses.POST, 'https://coveralls.io/webhook',
+                  json={'done': True}, status=200)
+    expected_json = {
+        'repo_token': 'xxx',
+        'repo_name': 'test/repo',
+        'payload': {
+            'status': 'done',
+            'build_num': '123456789'
+        }
+    }
+
+    coveralls.cli.main(argv=['--finish'])
+
+    mock_log.assert_has_calls(
+        [mock.call('Finishing parallel jobs...'),
+         mock.call('Done')])
+    assert len(responses.calls) == 1
+    assert req_json(responses.calls[0].request) == expected_json
+
+
+@mock.patch.dict(os.environ, {'TRAVIS': 'True'}, clear=True)
+@mock.patch.object(coveralls.cli.log, 'exception')
+@responses.activate
+def test_finish_exception(mock_log):
+    responses.add(responses.POST, 'https://coveralls.io/webhook',
+                  json={'error': 'Mocked'}, status=200)
+    expected_json = {
+        'payload': {
+            'status': 'done'
+        }
+    }
+    msg = 'Parallel finish failed: Mocked'
+
+    try:
+        coveralls.cli.main(argv=['--finish'])
+        assert 0 == 1  # Should never reach this line
+    except SystemExit:
+        pass
+
+    mock_log.assert_has_calls([mock.call(CoverallsException(msg))])
+    assert len(responses.calls) == 1
+    assert req_json(responses.calls[0].request) == expected_json
 
 
 @mock.patch.object(coveralls.cli.log, 'info')

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ passenv = *
 usedevelop = true
 deps =
     mock
+    responses
     pytest
     pyyaml: PyYAML>=3.10,<5.3
     cov41: coverage>=4.1,<5.0


### PR DESCRIPTION
Github Actions, and the coveralls side of support for it, seem to have changed/evolved.
This PR brings coveralls-python in line with the official github action, which is commonly used to finish parallel builds.

Additionally, there is no need to manually provide your repo token anymore (though you still can, so existing setups should not be affected by this), since the native github support takes the automatically provided GITHUB_TOKEN instead, very similar to how things work on Travis.
You do however have to export that GITHUB_TOKEN to an env var in your workflow.yml:

```
env:
  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
```