### PR TITLE
fix(api): use GITHUB_RUN_ID instead of GITHUB_SHA for the GitHub Actions service number

### DIFF
--- a/coveralls/api.py
+++ b/coveralls/api.py
@@ -92,11 +92,10 @@ class Coveralls:
 
     @staticmethod
     def load_config_from_github():
-        service_number = os.environ.get('GITHUB_SHA')
+        service_number = os.environ.get('GITHUB_RUN_ID')
         pr = None
         if os.environ.get('GITHUB_REF', '').startswith('refs/pull/'):
             pr = os.environ.get('GITHUB_REF', '//').split('/')[2]
-            service_number += '-PR-{}'.format(pr)
         return 'github-actions', service_number, pr
 
     @staticmethod

--- a/docs/usage/tox.rst
+++ b/docs/usage/tox.rst
@@ -66,7 +66,7 @@ All variables:
 
 - ``GITHUB_ACTIONS``
 - ``GITHUB_REF``
-- ``GITHUB_SHA``
+- ``GITHUB_RUN_ID``
 - ``GITHUB_HEAD_REF``
 
 Jenkins

--- a/tests/api/configuration_test.py
+++ b/tests/api/configuration_test.py
@@ -112,7 +112,7 @@ class NoConfiguration(unittest.TestCase):
         os.environ,
         {'GITHUB_ACTIONS': 'true',
          'GITHUB_REF': 'refs/pull/1234/merge',
-         'GITHUB_SHA': 'bb0e00166b28f49db04d6a8b8cb4bddb5afa529f',
+         'GITHUB_RUN_ID': '100',
          'GITHUB_HEAD_REF': 'fixup-branch'},
         clear=True)
     def test_github_no_config(self):
@@ -125,7 +125,7 @@ class NoConfiguration(unittest.TestCase):
         os.environ,
         {'GITHUB_ACTIONS': 'true',
          'GITHUB_REF': 'refs/heads/master',
-         'GITHUB_SHA': 'bb0e00166b28f49db04d6a8b8cb4bddb5afa529f',
+         'GITHUB_RUN_ID': '100',
          'GITHUB_HEAD_REF': ''},
         clear=True)
     def test_github_no_config_no_pr(self):

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -19,12 +19,12 @@ def test_output_to_file(tmpdir):
 @mock.patch.dict(os.environ, {}, clear=True)
 def test_load_config_from_github():
     """Check getting config from GH actions works when not in a PR."""
-    coveralls = Coveralls(repo_token='xxx')
-
     os.environ['GITHUB_RUN_ID'] = 'run_id'
     os.environ['GITHUB_REF'] = 'refs/push/somehash'
-    assert coveralls.load_config_from_github() == ('github-actions', 'run_id', None)
+    assert Coveralls.load_config_from_github() == (
+        'github-actions', 'run_id', None)
 
     os.environ['GITHUB_RUN_ID'] = 'run_id'
     os.environ['GITHUB_REF'] = 'refs/pull/123'
-    assert coveralls.load_config_from_github() == ('github-actions', 'run_id', '123')
+    assert Coveralls.load_config_from_github() == (
+        'github-actions', 'run_id', '123')

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -14,3 +14,17 @@ def test_output_to_file(tmpdir):
     report = test_log.read()
 
     assert json.loads(report)['repo_token'] == 'xxx'
+
+
+@mock.patch.dict(os.environ, {}, clear=True)
+def test_load_config_from_github():
+    """Check getting config from GH actions works when not in a PR."""
+    coveralls = Coveralls(repo_token='xxx')
+
+    os.environ['GITHUB_RUN_ID'] = 'run_id'
+    os.environ['GITHUB_REF'] = 'refs/push/somehash'
+    assert coveralls.load_config_from_github() == ('github-actions', 'run_id', None)
+
+    os.environ['GITHUB_RUN_ID'] = 'run_id'
+    os.environ['GITHUB_REF'] = 'refs/pull/123'
+    assert coveralls.load_config_from_github() == ('github-actions', 'run_id', '123')

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -18,7 +18,7 @@ def test_output_to_file(tmpdir):
 
 @mock.patch.dict(os.environ, {}, clear=True)
 def test_load_config_from_github():
-    """Check getting config from GH actions works when not in a PR."""
+    """Check getting config during a GH action works."""
     os.environ['GITHUB_RUN_ID'] = 'run_id'
     os.environ['GITHUB_REF'] = 'refs/push/somehash'
     assert Coveralls.load_config_from_github() == (

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -14,17 +14,3 @@ def test_output_to_file(tmpdir):
     report = test_log.read()
 
     assert json.loads(report)['repo_token'] == 'xxx'
-
-
-@mock.patch.dict(os.environ, {}, clear=True)
-def test_load_config_from_github():
-    """Check getting config during a GH action works."""
-    os.environ['GITHUB_RUN_ID'] = 'run_id'
-    os.environ['GITHUB_REF'] = 'refs/push/somehash'
-    assert Coveralls.load_config_from_github() == (
-        'github-actions', 'run_id', None)
-
-    os.environ['GITHUB_RUN_ID'] = 'run_id'
-    os.environ['GITHUB_REF'] = 'refs/pull/123'
-    assert Coveralls.load_config_from_github() == (
-        'github-actions', 'run_id', '123')

--- a/tests/git_test.py
+++ b/tests/git_test.py
@@ -113,7 +113,7 @@ class GitInfoTestBranch(GitTest):
     @mock.patch.dict(os.environ, {
         'GITHUB_ACTIONS': 'true',
         'GITHUB_REF': 'refs/pull/1234/merge',
-        'GITHUB_SHA': 'bb0e00166b28f49db04d6a8b8cb4bddb5afa529f',
+        'GITHUB_RUN_ID': '100',
         'GITHUB_HEAD_REF': 'fixup-branch'
     }, clear=True)
     def test_gitinfo_github_pr(self):
@@ -123,7 +123,7 @@ class GitInfoTestBranch(GitTest):
     @mock.patch.dict(os.environ, {
         'GITHUB_ACTIONS': 'true',
         'GITHUB_REF': 'refs/heads/master',
-        'GITHUB_SHA': 'bb0e00166b28f49db04d6a8b8cb4bddb5afa529f',
+        'GITHUB_RUN_ID': '100',
         'GITHUB_HEAD_REF': ''
     }, clear=True)
     def test_gitinfo_github_nopr(self):


### PR DESCRIPTION
<!--
Pull requests with untested code will not be merged right away; if you would like to speed up the review process, please write tests.

Please make sure your PR passes our CI requirements. You can run these locally with

    pre-commit run --all-files
    tox

If your work affects the public-facing API or usage of this project, please make sure to update the relevant documentation.
-->

The current implementation uses `GITHUB_SHA` to generate a unique service number for a GitHub Actions (of the format `{sha}-PR-{pr}`). This conflicts with the standard GitHub Action for coveralls (https://github.com/coverallsapp/github-action/blob/master/src/run.ts) which uses the unique `GITHUB_RUN_ID` and means that you can't have coverage for both Python & TypeScript in the same repo.

This change switches it to use `GITHUB_RUN_ID` when running within a GitHub Action.

### Note to the reviewer
- This run ID is unique within the repository, so it should be good enough for this use case. See https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables#default-environment-variables for more details.