### PR TITLE
add service number

### DIFF
--- a/coveralls/api.py
+++ b/coveralls/api.py
@@ -84,7 +84,7 @@ class Coveralls:
     @staticmethod
     def load_config_from_circle():
         pr = os.environ.get('CI_PULL_REQUEST', '').split('/')[-1] or None
-        return 'circle-ci', os.environ.get('CIRCLE_BUILD_NUM'), None, pr
+        return 'circle-ci', os.environ.get('CIRCLE_BUILD_NUM'), os.environ.get('CIRCLE_WORKFLOW_ID'), pr
 
     def load_config_from_github(self):
         service = 'github'


### PR DESCRIPTION
<!--
Pull requests with untested code will not be merged right away; if you would like to speed up the review process, please write tests.

Please make sure your PR passes our CI requirements. You can run these locally with

    pre-commit run --all-files
    tox

If your work affects the public-facing API or usage of this project, please make sure to update the relevant documentation.
-->

I *think* CIRCLE_WORKFLOW_ID maps to the `number` variable (aka [service_number](https://docs.coveralls.io/api-reference)) but I'm not 100% sure.
Note that node coveralls uses CIRCLE_WORKFLOW_ID as the service number. See https://github.com/nickmerwin/node-coveralls/blob/705c3b5963e3cc76f8e70381dbae20979008c9b8/lib/getOptions.js#L66