### PR TITLE
Fix typo in Tox docs

### DIFF
--- a/docs/usage/tox.rst
+++ b/docs/usage/tox.rst
@@ -40,7 +40,7 @@ BuildKite
 All variables:
 
 - ``BUILDKITE``
-- ``BUILDKIT_JOB_ID``
+- ``BUILDKITE_JOB_ID``
 - ``BUILDKITE_BRANCH``
 
 CircleCI


### PR DESCRIPTION
Looks like the buildkite environment variable was mistyped (missing an e)