### PR TITLE
Add workaround allowing resubmission

### DIFF
--- a/coveralls/api.py
+++ b/coveralls/api.py
@@ -2,8 +2,8 @@ import codecs
 import json
 import logging
 import os
-import re
 import random
+import re
 import sys
 
 import coverage
@@ -208,14 +208,16 @@ class Coveralls:
         # check and adjust/resubmit if submission looks like it
         # failed due to resubmission (non-unique)
         if response.status_code == 422:
-            self.config['service_job_id']='{}-{}'.format(self.config['service_job_id'],random.randint(0,sys.maxsize))
+            self.config['service_job_id'] = '{}-{}'.format(
+                self.config['service_job_id'], random.randint(0, sys.maxsize))
 
             # ensure create_report uses updated data
             self._data = None
 
-            print('resubmitting with id {}'.format(self.config['service_job_id']))
+            print('resubmitting with id {}'.format(
+                self.config['service_job_id']))
             response = requests.post(endpoint, files={'json_file': self.create_report()},
-                                 verify=verify)
+                                     verify=verify)
 
         try:
             response.raise_for_status()

--- a/coveralls/api.py
+++ b/coveralls/api.py
@@ -3,6 +3,8 @@ import json
 import logging
 import os
 import re
+import random
+import sys
 
 import coverage
 import requests
@@ -202,6 +204,19 @@ class Coveralls:
         verify = not bool(os.environ.get('COVERALLS_SKIP_SSL_VERIFY'))
         response = requests.post(endpoint, files={'json_file': json_string},
                                  verify=verify)
+
+        # check and adjust/resubmit if submission looks like it
+        # failed due to resubmission (non-unique)
+        if response.status_code == 422:
+            self.config['service_job_id']='{}-{}'.format(self.config['service_job_id'],random.randint(0,sys.maxsize))
+
+            # ensure create_report uses updated data
+            self._data = None
+
+            print('resubmitting with id {}'.format(self.config['service_job_id']))
+            response = requests.post(endpoint, files={'json_file': self.create_report()},
+                                 verify=verify)
+
         try:
             response.raise_for_status()
             return response.json()


### PR DESCRIPTION
As the commit/other information doesn't change when performing a
rebuild, resubmissions will fail with an HTTP 422 error. This adds a
workaround for such cases, appending a random value to the id and
attempting a resubmission with that.